### PR TITLE
Fix up ENTRYPOINT/CMD to be more flexible.

### DIFF
--- a/websphere-liberty/8.5.5/Dockerfile
+++ b/websphere-liberty/8.5.5/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:14.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yq wget \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # Install JRE
 ENV JRE_VERSION 1.7.1.1
@@ -53,3 +53,4 @@ EXPOSE 9080
 EXPOSE 9443
 
 ENTRYPOINT ["liberty-run"]
+CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/websphere-liberty/8.5.5/liberty-run
+++ b/websphere-liberty/8.5.5/liberty-run
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec /opt/ibm/docker/license-check /opt/ibm/wlp/bin/server run "$@"
+/opt/ibm/docker/license-check && exec "$@"

--- a/websphere-liberty/8.5.5/license-check
+++ b/websphere-liberty/8.5.5/license-check
@@ -15,13 +15,14 @@
 # limitations under the License.
 
 if [ "$LICENSE" = "accept" ]; then
-  exec "$@"
+  exit 0
 elif [ "$LICENSE" = "view" ]; then
   for f in /opt/ibm/docker/licenses/*
   do
     $f
     echo -e "\n\n====\n"
   done
+  exit 1
 else
   echo -e "Set environment variable LICENSE=accept to indicate acceptance of license terms and conditions.\n\nLicense agreements and information can be viewed by running this image with the environment variable LICENSE=view."
   exit 1


### PR DESCRIPTION
The ENTRYPOINT is now used for the LICENSE check, at which point the CMD
takes over and is executed directly via exec.  This also enables the
user to run arbitrary commands such as "productInfo version" directly.
It also enables a data volume container to be created directly from the
websphere-liberty image rather than something else based on ubuntu (to
get around the original ENTRYPOINT limitation).