### PR TITLE
Merge ibmjre back in

### DIFF
--- a/websphere-liberty/8.5.5/developer/common/README.md
+++ b/websphere-liberty/8.5.5/developer/common/README.md
@@ -1,6 +1,6 @@
 # WebSphere Application Server Developer Edition V8.5.5 Liberty Profile image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:common` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with features common to all the images and builds on the `java:jre` OpenJRE image.
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:common` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with  features common to all the images and an IBM Java Runtime Environment V8.
 
 # Usage
 

--- a/websphere-liberty/8.5.5/developer/javaee7/README.md
+++ b/websphere-liberty/8.5.5/developer/javaee7/README.md
@@ -1,6 +1,6 @@
 # WebSphere Application Server Developer Edition V8.5.5 Liberty Profile image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:javaee7` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with Java EE 7 Full Platform features and builds on the `java:jre` OpenJRE image.
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:javaee7` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with Java EE 7 Full Platform features and an IBM Java Runtime Environment V8.
 
 # Usage
 

--- a/websphere-liberty/8.5.5/developer/kernel/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/kernel/Dockerfile
@@ -12,13 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM java:jre
+FROM ubuntu:14.04
 
 MAINTAINER Kavitha Suresh Kumar <kavisuresh@in.ibm.com> (@kavi2002suresh)
 
 RUN apt-get update \
     && apt-get install -y wget unzip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install JRE
+ENV JRE_VERSION 1.8.0_sr1fp01
+RUN JRE_URL=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/jre/index.yml | sed -n '/'$JRE_VERSION'/{n;p}' | sed -n 's/\s*uri:\s//p' | tr -d '\r') \
+    && wget -q $JRE_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/ibm-java.bin \
+    && chmod +x /tmp/ibm-java.bin \
+    && echo "INSTALLER_UI=silent" > /tmp/response.properties \
+    && echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties \
+    && echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties \
+    && mkdir /opt/ibm \
+    && /tmp/ibm-java.bin -i silent -f /tmp/response.properties \
+    && rm /tmp/response.properties \
+    && rm /tmp/ibm-java.bin
+ENV JAVA_HOME /opt/ibm/java
+ENV PATH $JAVA_HOME/jre/bin:$PATH
+COPY license-check /opt/ibm/docker/
+COPY view-jre-license /opt/ibm/docker/licenses/
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 8.5.5_07
@@ -27,7 +44,6 @@ RUN LIBERTY_URL=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/softw
     && unzip -q /tmp/wlp.zip -d /opt/ibm \
     && rm /tmp/wlp.zip 	
 COPY view-wlp-license /opt/ibm/docker/licenses/	
-COPY license-check /opt/ibm/docker/
 COPY liberty-run /opt/ibm/wlp/bin/
 ENV PATH /opt/ibm/wlp/bin:$PATH
 

--- a/websphere-liberty/8.5.5/developer/kernel/README.md
+++ b/websphere-liberty/8.5.5/developer/kernel/README.md
@@ -1,6 +1,6 @@
 # WebSphere Application Server Developer Edition V8.5.5 Liberty Profile kernel image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:kernel` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 Kernel and builds on the `java:jre` OpenJRE image.
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:kernel` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 Kernel and an IBM Java Runtime Environment.
 
 # Usage
 

--- a/websphere-liberty/8.5.5/developer/kernel/view-jre-license
+++ b/websphere-liberty/8.5.5/developer/kernel/view-jre-license
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# (C) Copyright IBM Corporation 2014.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LL=${LANG-"en"}
+[[ ! -e "/opt/ibm/java/docs/$LL" ]] && LL="en"
+cat /opt/ibm/java/docs/$LL/license_$LL.txt

--- a/websphere-liberty/8.5.5/developer/webProfile6/README.md
+++ b/websphere-liberty/8.5.5/developer/webProfile6/README.md
@@ -1,6 +1,6 @@
 # WebSphere Application Server Developer Edition V8.5.5 Liberty Profile image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:webProfile6` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with Java EE 6 Web Profile features and builds on the `java:jre` OpenJRE image.
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:webProfile6` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with Java EE 6 Web Profile features and an IBM Java Runtime Environment V8.
 
 # Usage
 

--- a/websphere-liberty/8.5.5/developer/webProfile7/README.md
+++ b/websphere-liberty/8.5.5/developer/webProfile7/README.md
@@ -1,6 +1,6 @@
 # WebSphere Application Server Developer Edition V8.5.5 Liberty Profile image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:webProfile7` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with Java EE 7 Web Profile features and builds on the `java:jre` OpenJRE image.
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:webProfile7` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition V8.5.5 with Java EE 7 Web Profile features and an IBM Java Runtime Environment V8.
 
 # Usage
 

--- a/websphere-liberty/beta/Dockerfile
+++ b/websphere-liberty/beta/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM java:jre
+FROM ubuntu:14.04
 
 MAINTAINER David Currie <david_currie@uk.ibm.com> (@dcurrie)
 
@@ -20,13 +20,29 @@ RUN apt-get update \
     && apt-get install -y wget \
     && rm -rf /var/lib/apt/lists/*
 
+# Install JRE
+ENV JRE_VERSION 1.8.0_sr1fp01
+RUN JRE_URL=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/jre/index.yml | sed -n '/'$JRE_VERSION'/{n;p}' | sed -n 's/\s*uri:\s//p' | tr -d '\r') \
+    && wget -q $JRE_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/ibm-java.bin \
+    && chmod +x /tmp/ibm-java.bin \
+    && echo "INSTALLER_UI=silent" > /tmp/response.properties \
+    && echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties \
+    && echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties \
+    && mkdir /opt/ibm \
+    && /tmp/ibm-java.bin -i silent -f /tmp/response.properties \
+    && rm /tmp/response.properties \
+    && rm /tmp/ibm-java.bin
+ENV JAVA_HOME /opt/ibm/java
+ENV PATH $JAVA_HOME/jre/bin:$PATH
+COPY license-check /opt/ibm/docker/
+COPY view-jre-license /opt/ibm/docker/licenses/
+
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 2015.10.0_0
 RUN LIBERTY_URL=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml | sed -n '/'$LIBERTY_VERSION'/{n;p}' | sed -n 's/\s*uri:\s//p' | tr -d '\r') \
     && wget -q $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp-developers-runtime.jar \
     && java -jar /tmp/wlp-developers-runtime.jar --acceptLicense /opt/ibm \
     && rm /tmp/wlp-developers-runtime.jar 
-COPY license-check /opt/ibm/docker/
 COPY view-wlp-license /opt/ibm/docker/licenses/
 COPY liberty-run /opt/ibm/wlp/bin/
 ENV PATH /opt/ibm/wlp/bin:$PATH

--- a/websphere-liberty/beta/README.md
+++ b/websphere-liberty/beta/README.md
@@ -1,6 +1,6 @@
 # WebSphere Application Server Liberty v9 Beta with Java EE7 image for Docker
 
-The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:beta` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The resultant image contains the IBM WebSphere Application Server Liberty v9 Beta with Java EE7 and builds on the `java:jre` OpenJRE image.
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:beta` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The resultant image contains IBM WebSphere Application Server Liberty v9 Beta with Java EE7 and an IBM Java Runtime Environment.
 
 # Usage
 

--- a/websphere-liberty/beta/view-jre-license
+++ b/websphere-liberty/beta/view-jre-license
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# (C) Copyright IBM Corporation 2014.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LL=${LANG-"en"}
+[[ ! -e "/opt/ibm/java/docs/$LL" ]] && LL="en"
+cat /opt/ibm/java/docs/$LL/license_$LL.txt


### PR DESCRIPTION
Export controls are now in place on Docker Hub so merging IBM JRE back in to all images.