### PR TITLE
Runtime keystore password generation and server.xml update

### DIFF
--- a/websphere-liberty/8.5.5/developer/javaee7/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/javaee7/Dockerfile
@@ -14,6 +14,6 @@
 
 FROM websphere-liberty:webProfile7
 
-COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/ 
+COPY server.xml /config/
 RUN installUtility install --acceptLicense defaultServer \
-    && rm -rf /opt/ibm/wlp/usr/servers/defaultServer/workarea
+    && rm -rf /output/workarea

--- a/websphere-liberty/8.5.5/developer/javaee7/server.xml
+++ b/websphere-liberty/8.5.5/developer/javaee7/server.xml
@@ -1,18 +1,35 @@
-<server description="Default Server">
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Default server">
 
+    <!-- Enable features -->
     <featureManager>
         <feature>javaee-7.0</feature>
     </featureManager>
 
+    <!-- This template enables security. To get the full use of all the capabilities, a keystore and user registry are required. -->
+    
+    <!-- For the keystore, default keys are generated and stored in a keystore. To provide the keystore password, generate an 
+         encoded password using bin/securityUtility encode and add it below in the password attribute of the keyStore element. 
+         Then uncomment the keyStore element. -->
+    <!--
+    <keyStore password=""/> 
+    -->
+    
+    <!--For a user registry configuration, configure your user registry. For example, configure a basic user registry using the
+        basicRegistry element. Specify your own user name below in the name attribute of the user element. For the password, 
+        generate an encoded password using bin/securityUtility encode and add it in the password attribute of the user element. 
+        Then uncomment the user element. -->
     <basicRegistry id="basic" realm="BasicRealm"> 
-	<!-- <user name="yourUserName" password="" />  --> 
+        <!-- <user name="yourUserName" password="" />  --> 
     </basicRegistry>
+    
+    <!-- To allow access to this server from a remote client host="*" has been added to the following element -->
     <httpEndpoint id="defaultHttpEndpoint"
-		  host="*"
-                  httpPort="9080"
+                  host="*"
+		  httpPort="9080"
                   httpsPort="9443" />
-
-    <keyStore id="defaultKeyStore"
-              password="Liberty" />
+                  
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
 
 </server>

--- a/websphere-liberty/8.5.5/developer/webProfile6/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/webProfile6/Dockerfile
@@ -14,8 +14,9 @@
 
 FROM websphere-liberty:common
 
-COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/
+COPY server.xml /config/
+COPY docker-server /opt/ibm/docker/
+
 RUN installUtility install --acceptLicense appSecurity-1.0 blueprint-1.0 concurrent-1.0 oauth-2.0 osgiConsole-1.0 serverStatus-1.0 wab-1.0 timedOperations-1.0 \
     && installUtility install --acceptLicense defaultServer \
-    && rm -rf /opt/ibm/wlp/usr/servers/defaultServer/workarea 
-
+    && rm -rf /output/workarea 

--- a/websphere-liberty/8.5.5/developer/webProfile6/docker-server
+++ b/websphere-liberty/8.5.5/developer/webProfile6/docker-server
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Generate the keystore.xml
+PASSWORD=$(openssl rand -base64 32)
+XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password="$PASSWORD" /></server>"
+
+# Create the keystore.xml file and place in dropins
+mkdir -p /config/configDropins/defaults/
+echo $XML > /config/configDropins/defaults/keystore.xml
+
+# Pass on to the real server run
+exec /opt/ibm/wlp/bin/server $@

--- a/websphere-liberty/8.5.5/developer/webProfile6/server.xml
+++ b/websphere-liberty/8.5.5/developer/webProfile6/server.xml
@@ -1,15 +1,18 @@
-<server description="Default Server">
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Default server">
 
+    <!-- Enable features -->
     <featureManager>
         <feature>webProfile-6.0</feature>
     </featureManager>
 
+    <!-- To allow access to this server from a remote client host="*" has been added to the following element -->
     <httpEndpoint id="defaultHttpEndpoint"
-		  host="*"
-                  httpPort="9080"
+                  host="*"
+		  httpPort="9080"
                   httpsPort="9443" />
-
-    <keyStore id="defaultKeyStore"
-              password="Liberty" />
+                  
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
 
 </server>

--- a/websphere-liberty/8.5.5/developer/webProfile7/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/webProfile7/Dockerfile
@@ -14,6 +14,10 @@
 
 FROM websphere-liberty:common
 
-COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/
+COPY server.xml /config/
+COPY docker-server /opt/ibm/docker/
+
 RUN installUtility install --acceptLicense defaultServer \
-    && rm -rf /opt/ibm/wlp/usr/servers/defaultServer/workarea
+   && rm -rf /output/workarea
+
+CMD ["/opt/ibm/docker/docker-server", "run", "defaultServer"]

--- a/websphere-liberty/8.5.5/developer/webProfile7/docker-server
+++ b/websphere-liberty/8.5.5/developer/webProfile7/docker-server
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Generate the keystore.xml
+PASSWORD=$(openssl rand -base64 32)
+XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password="$PASSWORD" /></server>"
+
+# Create the keystore.xml file and place in dropins
+mkdir -p /config/configDropins/defaults/
+echo $XML > /config/configDropins/defaults/keystore.xml
+
+# Pass on to the real server run
+exec /opt/ibm/wlp/bin/server $@

--- a/websphere-liberty/8.5.5/developer/webProfile7/server.xml
+++ b/websphere-liberty/8.5.5/developer/webProfile7/server.xml
@@ -1,15 +1,18 @@
-<server description="Default Server">
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Default server">
 
+    <!-- Enable features -->
     <featureManager>
         <feature>webProfile-7.0</feature>
     </featureManager>
 
+    <!-- To allow access to this server from a remote client host="*" has been added to the following element -->
     <httpEndpoint id="defaultHttpEndpoint"
-		  host="*"
-                  httpPort="9080"
+                  host="*"
+		  httpPort="9080"
                   httpsPort="9443" />
-
-    <keyStore id="defaultKeyStore"
-              password="Liberty" />
+                  
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true"/>
 
 </server>


### PR DESCRIPTION
Not sure if there is a neater way to preserve double quote attributes in the docker-server script.