### PR TITLE
Remove logs directory left by installUtility

### DIFF
--- a/websphere-liberty/8.5.5/developer/javaee7/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/javaee7/Dockerfile
@@ -16,4 +16,4 @@ FROM websphere-liberty:webProfile7
 
 COPY server.xml /config/
 RUN installUtility install --acceptLicense defaultServer \
-    && rm -rf /config/workarea
+    && rm -rf /config/workarea /config/logs

--- a/websphere-liberty/8.5.5/developer/kernel/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/kernel/Dockerfile
@@ -56,7 +56,8 @@ ENV PATH=/opt/ibm/wlp/bin:$PATH
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ibm/wlp/output
-RUN ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+RUN mkdir /logs \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
 
 # Configure WebSphere Liberty

--- a/websphere-liberty/8.5.5/developer/webProfile6/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/webProfile6/Dockerfile
@@ -19,6 +19,6 @@ COPY docker-server /opt/ibm/docker/
 
 RUN installUtility install --acceptLicense appSecurity-1.0 blueprint-1.0 concurrent-1.0 oauth-2.0 osgiConsole-1.0 serverStatus-1.0 wab-1.0 timedOperations-1.0 \
     && installUtility install --acceptLicense defaultServer \
-    && rm -rf /config/workarea
+    && rm -rf /config/workarea /config/logs
 
 CMD ["/opt/ibm/docker/docker-server", "run", "defaultServer"]

--- a/websphere-liberty/8.5.5/developer/webProfile7/Dockerfile
+++ b/websphere-liberty/8.5.5/developer/webProfile7/Dockerfile
@@ -18,6 +18,6 @@ COPY server.xml /config/
 COPY docker-server /opt/ibm/docker/
 
 RUN installUtility install --acceptLicense defaultServer \
-   && rm -rf /config/workarea
+   && rm -rf /config/workarea /config/logs
 
 CMD ["/opt/ibm/docker/docker-server", "run", "defaultServer"]

--- a/websphere-liberty/8.5.5/production-install/add/Dockerfile
+++ b/websphere-liberty/8.5.5/production-install/add/Dockerfile
@@ -41,8 +41,9 @@ ENV PATH /opt/ibm/wlp/bin:$PATH
 # Set Path Shortcuts
 ENV LOG_DIR /logs
 ENV WLP_OUTPUT_DIR /opt/ibm/wlp/output
-RUN ln -s $WLP_OUTPUT_DIR/defaultServer /output \
-  && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
+RUN mkdir /logs \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \

--- a/websphere-liberty/8.5.5/production-install/wget/Dockerfile
+++ b/websphere-liberty/8.5.5/production-install/wget/Dockerfile
@@ -41,8 +41,9 @@ ENV PATH /opt/ibm/wlp/bin:$PATH
 # Set Path Shortcuts
 ENV LOG_DIR /logs
 ENV WLP_OUTPUT_DIR /opt/ibm/wlp/output
-RUN ln -s $WLP_OUTPUT_DIR/defaultServer /output \
-  && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
+RUN mkdir /logs \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \

--- a/websphere-liberty/beta/Dockerfile
+++ b/websphere-liberty/beta/Dockerfile
@@ -56,7 +56,8 @@ ENV PATH=/opt/ibm/wlp/bin:$PATH
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ibm/wlp/output
-RUN ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+RUN mkdir /logs \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
 
 # Configure WebSphere Liberty


### PR DESCRIPTION
As per https://github.com/WASdev/ci.docker/issues/69, installUtility when run against a server configuration is leaving behind a logs directory in /config/logs which, as well as wasting space, is confusing to users when the actual server logs will end up in /logs. Cleaning up this directory and also creating the directory /logs to help signpost this location.