### PR TITLE
Removed workarea and added test

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir /logs \
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
 COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/
 EXPOSE 9080 9443
 

--- a/ga/developer/javaee7/Dockerfile
+++ b/ga/developer/javaee7/Dockerfile
@@ -15,6 +15,5 @@
 FROM websphere-liberty:webProfile7
 
 COPY server.xml /config/
-RUN touch /config/server.xml \
-    && installUtility install --acceptLicense defaultServer \
-    && rm -rf /config/workarea /config/logs
+RUN installUtility install --acceptLicense defaultServer \
+    && rm -rf /output/workarea /output/logs

--- a/ga/developer/kernel/Dockerfile
+++ b/ga/developer/kernel/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir /logs \
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
 EXPOSE 9080 9443
 
 CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/ga/developer/webProfile6/Dockerfile
+++ b/ga/developer/webProfile6/Dockerfile
@@ -19,6 +19,6 @@ COPY docker-server /opt/ibm/docker/
 
 RUN installUtility install --acceptLicense appSecurity-1.0 blueprint-1.0 concurrent-1.0 oauth-2.0 osgiConsole-1.0 serverStatus-1.0 wab-1.0 timedOperations-1.0 \
     && installUtility install --acceptLicense defaultServer \
-    && rm -rf /config/workarea /config/logs
+    && rm -rf /output/workarea /output/logs
 
 CMD ["/opt/ibm/docker/docker-server", "run", "defaultServer"]

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -17,8 +17,7 @@ FROM websphere-liberty:common
 COPY server.xml /config/
 COPY docker-server /opt/ibm/docker/
 
-RUN touch /config/server.xml \
-   && installUtility install --acceptLicense defaultServer \
-   && rm -rf /config/workarea /config/logs
+RUN installUtility install --acceptLicense defaultServer \
+   && rm -rf /output/workarea /output/logs
 
 CMD ["/opt/ibm/docker/docker-server", "run", "defaultServer"]

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -16,7 +16,7 @@ waitForServerStart()
 {
    cid=$1
    count=${2:-1}
-   end=$((SECONDS+60))
+   end=$((SECONDS+120))
    while (( $SECONDS < $end && $(docker inspect -f {{.State.Running}} $cid) == "true" ))
    do
       result=$(docker logs $cid |& grep "CWWKF0011I" | wc -l)
@@ -128,6 +128,17 @@ testFeatureList()
    then
       echo "Incorrect features installed, exiting"
       echo "$comparison"
+      exit 1
+   fi
+}
+
+testWorkareaRemoved()
+{
+   numberOfOccurences=$(docker run --rm $image find . -type d -name workarea | wc -l)
+
+   if [ $numberOfOccurences != 0 ]
+   then
+      echo "Image $image contains workarea"
       exit 1
    fi
 }


### PR DESCRIPTION
Added a test to check if workarea directory is present. Removed workarea in Dockerfile for beta, kernel, javaee, webProfile6 and webProfile7. Removed "touch" command from javaee7 and webProfile7 Dockerfiles because workarea is no longer present. Increased timeout for liberty to start while testing from 60 seconds to 120.