### PR TITLE
Fix syncrepo script and update beta

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install WebSphere Liberty
-ENV LIBERTY_VERSION 2017.5.0_0
+ENV LIBERTY_VERSION 2017.6.0_0
 RUN LIBERTY_URL=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 3 | sed -n 's/\s*webProfile7:\s//p' | tr -d '\r')  \
     && echo $LIBERTY_URL \
     && wget -q $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp-beta.zip \

--- a/tools/syncRepository.sh
+++ b/tools/syncRepository.sh
@@ -46,7 +46,7 @@ pullAndSync()
     then
         echo "Syncing websphere-liberty:$tag image......"
         docker rmi $target/websphere-liberty:$tag
-        docker tag -f websphere-liberty:$tag $target/websphere-liberty:$tag
+        docker tag websphere-liberty:$tag $target/websphere-liberty:$tag
         docker push $target/websphere-liberty:$tag
         if [ $?  = 0 ]
         then


### PR DESCRIPTION
The syncRepo script was throwing an error due to the fact that we are using the -f variable that is now deprecated. 