### PR TITLE
Product labels and LICENSE variable

### DIFF
--- a/ga/developer/kernel/Dockerfile
+++ b/ga/developer/kernel/Dockerfile
@@ -30,6 +30,11 @@ RUN LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/e
     && rm /tmp/wlp.zip
 ENV PATH=/opt/ibm/wlp/bin:$PATH
 
+# Add labels for consumption by IBM Product Insights
+LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
+      "ProductName"="WebSphere Application Server Liberty" \
+      "ProductVersion"="17.0.0.3"
+
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ibm/wlp/output

--- a/ga/developer/kernel/docker-server
+++ b/ga/developer/kernel/docker-server
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+case "${LICENSE,,}" in
+  "accept" ) # Suppress license message in logs
+    grep -s -F "com.ibm.ws.logging.hideMessage" /config/bootstrap.properties \
+      && sed -i 's/^\(com.ibm.ws.logging.hideMessage=.*$\)/\1,CWWKE0100I/' /config/bootstrap.properties \
+      || echo "com.ibm.ws.logging.hideMessage=CWWKE0100I" >> /config/bootstrap.properties
+    ;;
+  "view" ) # Display license file
+    cat /opt/ibm/wlp/lafiles/LI_${LANG:-en}
+    exit 1
+    ;;
+  "" ) # Continue, displaying license message in logs
+    true
+    ;;
+  *) # License not accepted
+    echo -e "Set environment variable LICENSE=accept to indicate acceptance of license terms and conditions.\n\nLicense agreements and information can be viewed by running this image with the environment variable LICENSE=view.  You can also set the LANG environment variable to view the license in a different language."
+    exit 1
+    ;;
+esac
+
 keystorePath="/config/configDropins/defaults/keystore.xml"
 
 if [ ! -e $keystorePath ]


### PR DESCRIPTION
Add product labels required by Product Insights and LICENSE environment variable that can be used to suppress the developer licensed message. The latter will be used by the Helm chart in IBM Cloud Private where the image will be licensed for production use.