### PR TITLE
Adding start/stop optimization to all images via ONBUILD

### DIFF
--- a/ga/developer/javaee7/Dockerfile
+++ b/ga/developer/javaee7/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015.
+# (C) Copyright IBM Corporation 2015,2018.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:webProfile7
+FROM websphere-liberty:kernel
 
-COPY server.xml /config/
+#ONBUILD will install javaee-7.0
+
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
-    && installUtility install --acceptLicense appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
+    && installUtility install --acceptLicense appSecurity-2.0 bluemixUtility-1.0 collectiveMember-1.0 ldapRegistry-3.0 \
+    localConnector-1.0 microProfile-1.0 microProfile-1.2 microProfile-1.3 monitor-1.0 restConnector-1.0 \
+    requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
+    webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaeeClient-7.0\
     && if [ ! -z $REPOSITORIES_PROPERTIES ] ; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
     && rm -rf /output/workarea /output/logs

--- a/ga/developer/kernel/Dockerfile
+++ b/ga/developer/kernel/Dockerfile
@@ -48,5 +48,14 @@ RUN /opt/ibm/wlp/bin/server create \
 COPY docker-server /opt/ibm/docker/
 EXPOSE 9080 9443
 
+# These instructions will be run in images built FROM this image
+ONBUILD COPY server.xml /config/
+ONBUILD ARG REPOSITORIES_PROPERTIES=""
+ONBUILD RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense defaultServer \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && server start && server stop && rm -rf /output/logs
+
 ENTRYPOINT ["/opt/ibm/docker/docker-server"]
 CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -14,16 +14,15 @@
 
 FROM websphere-liberty:kernel
 
+#ONBUILD will install microprofile-1.3
+
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     appSecurity-2.0 bluemixUtility-1.0 collectiveMember-1.0 ldapRegistry-3.0 \
-    localConnector-1.0 microProfile-1.0 microProfile-1.2 microProfile-1.3 monitor-1.0 restConnector-1.0 \
+    localConnector-1.0 microProfile-1.0 microProfile-1.2 monitor-1.0 restConnector-1.0 \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
-  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
-
-COPY server.xml /config/
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi 

--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -25,4 +25,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     localConnector-1.0 microProfile-1.0 microProfile-1.2 monitor-1.0 restConnector-1.0 \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
-  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi 
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs

--- a/ga/developer/webProfile6/Dockerfile
+++ b/ga/developer/webProfile6/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2014,2015.
+# (C) Copyright IBM Corporation 2014,2018.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,14 @@
 
 FROM websphere-liberty:kernel
 
-ARG REPOSITORIES_PROPERTIES=""
+#ONBUILD will install webProfile-6.0
 
-COPY server.xml /config/
+ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
     && installUtility install --acceptLicense \
     collectiveMember-1.0 monitor-1.0 webCache-1.0 ldapRegistry-3.0 appSecurity-2.0 localConnector-1.0 restConnector-1.0 ssl-1.0 sessionDatabase-1.0 \
     appSecurity-1.0 blueprint-1.0 concurrent-1.0 oauth-2.0 osgiConsole-1.0 serverStatus-1.0 wab-1.0 timedOperations-1.0 \
-    webProfile-6.0 \
     && if [ ! -z $REPOSITORIES_PROPERTIES ] ; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
     && rm -rf /output/workarea /output/logs

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM websphere-liberty:kernel
 
+#ONBUILD will install webProfile-7.0
+
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -22,8 +24,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     appSecurity-2.0 bluemixUtility-1.0 collectiveMember-1.0 ldapRegistry-3.0 \
     localConnector-1.0 microProfile-1.0 microProfile-1.2 microProfile-1.3 monitor-1.0 restConnector-1.0 \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
-    webCache-1.0 webProfile-7.0 \
+    webCache-1.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
-
-COPY server.xml /config/

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -30,6 +30,23 @@ waitForServerStart()
    return 1
 }
 
+waitForServerStop()
+{
+   cid=$1
+   end=$((SECONDS+120))
+   while (( $SECONDS < $end ))
+   do
+      result=$(docker logs $cid 2>&1 | grep "CWWKE0036I" | wc -l)
+      if [ $result = 1 ]
+      then
+         return 0
+      fi
+   done
+
+   echo "Liberty failed to stop within a reasonable time"
+   return 1
+}
+
 testLibertyStarts()
 {
    cid=$(docker run -d $image)
@@ -70,6 +87,7 @@ testLibertyStops()
       exit 1
    fi
 
+   waitForServerStop $cid
    docker logs $cid | grep -iq "CWWKE0036I"
    if [ $? != 0 ]
    then


### PR DESCRIPTION
The main goal of this PR is to introduce class caching to the WebSphere Liberty images, via server start/stop priming.  

This is achieved by using `ONBUILD` instructions, which are applied to the first `FROM` statement that includes the image (doesn't propagate into grandchildren images).  

I took advantage that our non-kernel images have a server.xml in the same folder as the Dockerfile to be able to copy the relevant server.xml, pull its features and then prime the server based on those features.  

The only part of this PR which I had to think twice is that direct users of `kernel` are now required to have server.xml in the same folder as the Dockerfile - however, given that's our recommendation in the official Docker Hub page, I think it's reasonable.  

Also, I had to change the image dependency of the `javaee7` tag to be directly from kernel, otherwise we wouldn't get the necessary class caching from the kernel's ONBUILD, and if we explicitly put the server start/stop in `javaee7` it would incur the image size increase from `webProfile7` + `javaee7`. 


Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>