### PR TITLE
Prime the server to improve startup performance

### DIFF
--- a/ga/developer/javaee7/Dockerfile
+++ b/ga/developer/javaee7/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging && rm -rf /output/workarea
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging

--- a/ga/developer/javaee7/Dockerfile
+++ b/ga/developer/javaee7/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015.
+# (C) Copyright IBM Corporation 2015,2018.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:webProfile7
+FROM websphere-liberty:kernel
 
-COPY server.xml /config/
 ARG REPOSITORIES_PROPERTIES=""
 
-RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
-    && installUtility install --acceptLicense appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
-    && if [ ! -z $REPOSITORIES_PROPERTIES ] ; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-    && rm -rf /output/workarea /output/logs
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense \
+    appSecurity-2.0 bluemixUtility-1.0 collectiveMember-1.0 ldapRegistry-3.0 \
+    localConnector-1.0 microProfile-1.0 microProfile-1.2 microProfile-1.3 monitor-1.0 restConnector-1.0 \
+    requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
+    webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs
+
+COPY server.xml /config/
+
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging

--- a/ga/developer/javaee7/Dockerfile
+++ b/ga/developer/javaee7/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging && rm -rf /output/workarea

--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/workarea

--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -27,3 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && rm -rf /output/workarea /output/logs
 
 COPY server.xml /config/
+
+RUN server start && server stop && rm -rf /output/resources/security/

--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/workarea
+RUN server start && server stop && rm -rf /output/resources/security/

--- a/ga/developer/webProfile6/Dockerfile
+++ b/ga/developer/webProfile6/Dockerfile
@@ -27,4 +27,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/workarea
+RUN server start && server stop && rm -rf /output/resources/security/

--- a/ga/developer/webProfile6/Dockerfile
+++ b/ga/developer/webProfile6/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2014,2015.
+# (C) Copyright IBM Corporation 2014,2018.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@ FROM websphere-liberty:kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 
-COPY server.xml /config/
-
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
     && installUtility install --acceptLicense \
@@ -26,3 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     webProfile-6.0 \
     && if [ ! -z $REPOSITORIES_PROPERTIES ] ; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
     && rm -rf /output/workarea /output/logs
+
+COPY server.xml /config/
+
+RUN server start && server stop && rm -rf /output/resources/security/

--- a/ga/developer/webProfile6/Dockerfile
+++ b/ga/developer/webProfile6/Dockerfile
@@ -27,4 +27,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/workarea

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -27,3 +27,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && rm -rf /output/workarea /output/logs
 
 COPY server.xml /config/
+
+RUN server start && server stop && rm -rf /output/resources/security/
+

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/workarea
 

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/workarea
+RUN server start && server stop && rm -rf /output/resources/security/
 

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -30,6 +30,23 @@ waitForServerStart()
    return 1
 }
 
+waitForServerStop()
+{
+   cid=$1
+   end=$((SECONDS+120))
+   while (( $SECONDS < $end ))
+   do
+      result=$(docker logs $cid 2>&1 | grep "CWWKE0036I" | wc -l)
+      if [ $result = 1 ]
+      then
+         return 0
+      fi
+   done
+
+   echo "Liberty failed to stop within a reasonable time"
+   return 1
+}
+
 testLibertyStarts()
 {
    cid=$(docker run -d $image)
@@ -70,6 +87,7 @@ testLibertyStops()
       exit 1
    fi
 
+   waitForServerStop $cid
    docker logs $cid | grep -iq "CWWKE0036I"
    if [ $? != 0 ]
    then
@@ -118,7 +136,7 @@ testFeatureList()
 {
    version=$(docker run --rm $image sh -c 'echo $LIBERTY_VERSION')
    echo "Checking features for $image against version $version"
-   
+
    case $tag in
      microProfile)
        YAML_KEY='microProfile1'
@@ -132,13 +150,13 @@ testFeatureList()
      *)
        YAML_KEY=$tag
    esac
-   
+
    LIBERTY_URL=$(wget -qO- https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml | grep $version -A 7 | sed -n "s/\s*$YAML_KEY:\s//p" | tr -d '\r' | head -n 1)
    if [ -z $LIBERTY_URL ]; then
      echo "WARNING: download not found - unable to verify features"
-     return 
+     return
    fi
-   
+
    if [[ $LIBERTY_URL == *jar ]]; then
      required_features=$(docker run --rm ibmjava:8-jre-alpine sh -c \
        "wget -q $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.jar
@@ -150,15 +168,15 @@ java -jar /tmp/wlp.jar --acceptLicense /opt/ibm > /dev/null
 unzip -q /tmp/wlp.zip -d /opt/ibm
 /opt/ibm/wlp/bin/productInfo featureInfo" | cut -d ' ' -f1 | sort)
    fi
-   
+
    actual_features=$(docker run --rm $image productInfo featureInfo | cut -d " " -f1 | sort)
-   
+
    additional_features=$(comm -1 -3 <(echo "$required_features") <(echo "$actual_features"))
    if [ "$additional_features" != "" ]; then
      echo "Additional features installed"
      echo "$additional_features"
    fi
-   
+
    missing_features=$(comm -2 -3 <(echo "$required_features") <(echo "$actual_features"))
    if [ "$missing_features" != "" ]; then
      echo "Missing features, exiting"
@@ -185,4 +203,3 @@ do
    eval $name
    echo "*** $name - Completed successfully"
 done
-

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -185,17 +185,6 @@ unzip -q /tmp/wlp.zip -d /opt/ibm
    fi
 }
 
-testWorkareaRemoved()
-{
-   numberOfOccurences=$(docker run --rm $image find . -type d -name workarea | wc -l)
-
-   if [ $numberOfOccurences != 0 ]
-   then
-      echo "Image $image contains workarea"
-      exit 1
-   fi
-}
-
 tests=$(declare -F | cut -d" " -f3 | grep "test")
 for name in $tests
 do


### PR DESCRIPTION
Adding a server start/stop to the images (except kernel, since there's no server.xml in there) to improve startup time.  There's a tradeoff with image sizes, as noted below:

microprofile:  increase of 63 MB.   startup from 8 seconds to 3 seconds
webProfile7:   increase of 64 MB.   startup from 9 seconds to 4 seconds
javaee7:      increase of  63 MB.   startup from 12 seconds to 5 seconds

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>