### PR TITLE
CentOS and RHEL dockerfiles

### DIFF
--- a/ga/developer/centos/README.md
+++ b/ga/developer/centos/README.md
@@ -1,0 +1,7 @@
+# WebSphere Application Server Developer Edition Liberty CentOS image for Docker
+
+The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:centos` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition Liberty Java EE7 + MicroProfile and an IBM Java Runtime Environment, built on top of the CentOS operating system.
+
+# Usage
+
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/developer/centos` directory and then issuing the command `docker build .`.

--- a/ga/developer/rhel/Dockerfile
+++ b/ga/developer/rhel/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:latest
+FROM registry.access.redhat.com/rhel7
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
 
@@ -28,22 +28,18 @@ RUN yum makecache fast \
 
 # Create a non-root user
 RUN useradd -m wlp \
-    && mkdir /opt/ibm \
-    && chown -R wlp /opt/ibm
+    && mkdir /opt/ibm
 
 # Create directories we'll copy artifacts into
 RUN mkdir -p /opt/ibm/java && mkdir -p /opt/ibm/wlp && mkdir -p /opt/ibm/docker
     
-# Copy IBM Java from external image
-COPY --from=websphere-liberty --chown=wlp /opt/ibm/java /opt/ibm/java
-ENV JAVA_HOME=/opt/ibm/java
+# Copy IBM Java, WebSphere Liberty and docker-server into the image
+ADD ibm /opt/ibm
+RUN chmod -R 777 /opt/ibm
 
-# Copy WebSphere Liberty from external image
-COPY --from=websphere-liberty --chown=wlp /opt/ibm/wlp /opt/ibm/wlp
+ENV JAVA_HOME=/opt/ibm/java
 ENV PATH=/opt/ibm/wlp/bin:$PATH
 
-# Copy the starting script from external image
-COPY --from=websphere-liberty --chown=wlp /opt/ibm/docker /opt/ibm/docker
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
@@ -51,12 +47,11 @@ ENV LOG_DIR=/logs \
 
 RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
-    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config
-
-RUN mkdir /config/configDropins \
-    && chown -R  wlp /output \
-    && chown -R  wlp /config \
-    && chown -R  wlp /logs
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
+    && mkdir /config/configDropins \ 
+    && chmod -R 777 /output \
+    && chmod -R 777 /config/configDropins \
+    && chmod -R 777 /logs
 
 USER wlp
 

--- a/ga/developer/rhel/Dockerfile.build
+++ b/ga/developer/rhel/Dockerfile.build
@@ -1,5 +1,0 @@
-FROM websphere-liberty
-RUN useradd -m wlp
-USER wlp
-ADD ibm /opt/ibm
-RUN /opt/ibm ls -l

--- a/ga/developer/rhel/Dockerfile.build
+++ b/ga/developer/rhel/Dockerfile.build
@@ -1,0 +1,5 @@
+FROM websphere-liberty
+RUN useradd -m wlp
+USER wlp
+ADD ibm /opt/ibm
+RUN /opt/ibm ls -l

--- a/ga/developer/rhel/Dockerfile.rhel
+++ b/ga/developer/rhel/Dockerfile.rhel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:latest
+FROM registry.access.redhat.com/rhel7
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
 
@@ -25,11 +25,13 @@ RUN yum makecache fast \
     && yum clean all \
     && rm -rf /var/cache/yum \
     && rm -rf /var/tmp/yum-*
+
+
+# Create directories we'll copy artifacts into
+RUN mkdir -p /opt/ibm/java && mkdir -p /opt/ibm/wlp && mkdir -p /opt/ibm/docker
     
 # Copy IBM Java, WebSphere Liberty and docker-server into the image
-COPY --from=websphere-liberty /opt/ibm/java /opt/ibm/java
-COPY --from=websphere-liberty /opt/ibm/wlp /opt/ibm/wlp
-COPY --from=websphere-liberty /opt/ibm/docker /opt/ibm/docker
+ADD ibm /opt/ibm
 
 # Set environment vars and shorcuts
 ENV JAVA_HOME=/opt/ibm/java \
@@ -41,9 +43,9 @@ ENV JAVA_HOME=/opt/ibm/java \
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
+    && mkdir /config/configDropins \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
-    && mkdir /config/configDropins \
     && useradd -u 1001 -r -g 0 -s /sbin/nologin default \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
@@ -57,6 +59,7 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs
 
 USER 1001
+
 
 EXPOSE 9080 9443
 ENTRYPOINT ["/opt/ibm/docker/docker-server"]

--- a/ga/developer/rhel/Dockerfile.rhelatomic
+++ b/ga/developer/rhel/Dockerfile.rhelatomic
@@ -12,48 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7-atomic
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
 
 # Operating System update
-RUN yum makecache fast \
-    && yum update \
-    && yum -y install openssl \
-    && yum clean packages \
-    && yum clean headers \
-    && yum clean all \
-    && rm -rf /var/cache/yum \
-    && rm -rf /var/tmp/yum-*
-
-# Create a non-root user
-RUN useradd -m wlp \
-    && mkdir /opt/ibm
-
-# Create directories we'll copy artifacts into
-RUN mkdir -p /opt/ibm/java && mkdir -p /opt/ibm/wlp && mkdir -p /opt/ibm/docker
+RUN microdnf --enablerepo=rhel-7-server-rpms install openssl shadow-utils \
+    && microdnf clean all
     
 # Copy IBM Java, WebSphere Liberty and docker-server into the image
 ADD ibm /opt/ibm
-RUN chmod -R 777 /opt/ibm
 
-ENV JAVA_HOME=/opt/ibm/java
-ENV PATH=/opt/ibm/wlp/bin:$PATH
+# Set environment vars and shorcuts
+ENV JAVA_HOME=/opt/ibm/java \
+    PATH=/opt/ibm/wlp/bin:$PATH \
+    LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    RANDFILE=/tmp/.rnd \
+    JVM_ARGS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
-
-# Set Path Shortcuts
-ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
-
+# Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
+    && mkdir /config/configDropins \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
-    && mkdir /config/configDropins \ 
-    && chmod -R 777 /output \
-    && chmod -R 777 /config/configDropins \
-    && chmod -R 777 /logs
+    && useradd -u 1001 -r -g 0 -s /sbin/nologin default \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /opt/ibm/docker/docker-server \
+    && chmod -R g+rwx /opt/ibm/docker/docker-server \
+    && chown -R 1001:0 /opt/ibm/wlp/usr/servers/defaultServer \
+    && chmod -R g+rw /opt/ibm/wlp/usr/servers/defaultServer \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rw /opt/ibm/wlp/output \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs
 
-USER wlp
+USER 1001
 
 EXPOSE 9080 9443
 ENTRYPOINT ["/opt/ibm/docker/docker-server"]

--- a/ga/developer/rhel/README.md
+++ b/ga/developer/rhel/README.md
@@ -6,6 +6,8 @@ The instructions below assume you are building from a RHEL (or RHEL-atomic) oper
 
 Due to RHEL's version of docker being behind the latest docker versions we cannot use multi-stage builds (i.e. can't use `--from`) nor the integrated `chown` support for `ADD` or `COPY` instructions.
 
+If you wish to use Docker EE instead of RHEL's docker, you can follow [Docker's instructions](https://docs.docker.com/install/linux/docker-ee/rhel/), which will allow you to use a much newer version of the docker daemon but please be aware there's currently an [issue](https://serverfault.com/questions/809544/redhat-container-on-pure-docker-engine/) where the RHEL subscription from the docker host is not propagated into the docker image.  The suggested workaround is to mount the RHEL license from the docker host into the docker container.
+
 # Usage
 
 ## Pull files from base image
@@ -13,7 +15,7 @@ Due to RHEL's version of docker being behind the latest docker versions we canno
 `docker cp wlp:/opt/ibm .`
 
 ## Build RHEL-Liberty image
-`docker build -t rhel_wlp Dockerfile.rhel`
+`docker build -t rhel_wlp . -f Dockerfile.rhel`
 
 ## Build RHEL-atomic-Liberty image
-`docker build -t rhelatomic_wlp Dockerfile.rhelatomic`
+`docker build -t rhelatomic_wlp . -f Dockerfile.rhelatomic`

--- a/ga/developer/rhel/README.md
+++ b/ga/developer/rhel/README.md
@@ -1,0 +1,19 @@
+# WebSphere Application Server Developer Edition Liberty RHEL / RHEL-atomic image for Docker
+
+The Dockerfiles in this directory build an image that contains IBM WebSphere Application Server Developer Edition Liberty Java EE7 + MicroProfile and an IBM Java Runtime Environment, built on top of the RHEL (or RHEL-atomic) operating system.
+
+The instructions below assume you are building from a RHEL (or RHEL-atomic) operating system machine that is appropriately registered with Red Hat, and have [setup docker](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/get_started_with_docker_formatted_container_images#getting_docker_in_rhel_7) in RHEL.
+
+Due to RHEL's version of docker being behind the latest docker versions we cannot use multi-stage builds (i.e. can't use `--from`) nor the integrated `chown` support for `ADD` or `COPY` instructions.
+
+# Usage
+
+## Pull files from base image
+`docker create --name wlp websphere-liberty`
+`docker cp wlp:/opt/ibm .`
+
+## Build RHEL-Liberty image
+`docker build -t rhel_wlp Dockerfile.rhel`
+
+## Build RHEL-atomic-Liberty image
+`docker build -t rhelatomic_wlp Dockerfile.rhelatomic`


### PR DESCRIPTION
- Added new dockerfiles for RHEL and RHEL-atomic (just for sample purposes, not going to distribute these in Docker Hub, since they need a subscription to Red Hat)
- Update CentOS dockerfile to be more consistent with RHEL's dockerfiles

CentOS + WLP:  674MB
RHEL + WLP: 667 MB
RHEL-atomic + WLP:  548 MB