### PR TITLE
Add sleep to server stop test to fix intermittent errors

### DIFF
--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && sleep 20 && server stop && rm -rf /output/resources/security/

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && sleep 20 && server stop && rm -rf /output/resources/security/
 

--- a/test/build.sh
+++ b/test/build.sh
@@ -32,7 +32,7 @@ echo "**************************************************************************
 echo "           Starting docker build for $image                                   "
 echo "******************************************************************************"
 
-docker build --no-cache=true -t $image $dloc  > build_$tag.log
+docker build --no-cache=true -t $image $dloc  # show output to avoid 10 minute Travis timeout
 
 if [ $? = 0 ]
 then

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -79,6 +79,7 @@ testLibertyStops()
    cid=$(docker run -d $image)
    waitForServerStart $cid
 
+   sleep 20
    result=$(docker stop $cid)
    if [ $? != 0 ]
    then


### PR DESCRIPTION
Fixing the problem with testLibertyStops, where the shutdown happens before the server is fully started, causing Liberty not to stop properly.