### PR TITLE
Removing ONBUILD as requested by Docker

### DIFF
--- a/ga/developer/javaee7/Dockerfile
+++ b/ga/developer/javaee7/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-ONBUILD RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging

--- a/ga/developer/javaee8/Dockerfile
+++ b/ga/developer/javaee8/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-ONBUILD RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging
+RUN server start && server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging

--- a/ga/developer/microProfile/Dockerfile
+++ b/ga/developer/microProfile/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-ONBUILD RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/

--- a/ga/developer/webProfile6/Dockerfile
+++ b/ga/developer/webProfile6/Dockerfile
@@ -27,4 +27,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-ONBUILD RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/

--- a/ga/developer/webProfile7/Dockerfile
+++ b/ga/developer/webProfile7/Dockerfile
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-ONBUILD RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/
 

--- a/ga/developer/webProfile8/Dockerfile
+++ b/ga/developer/webProfile8/Dockerfile
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-ONBUILD RUN server start && server stop && rm -rf /output/resources/security/
+RUN server start && server stop && rm -rf /output/resources/security/
 


### PR DESCRIPTION
When compressed the image size only differs by about 3 MB, so not worth putting the `ONBUILD` instruction in the image.

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>