### PR TITLE
Moved configDropins dir creation to Dockerfile

### DIFF
--- a/ga/developer/rhel/kernel/Dockerfile
+++ b/ga/developer/rhel/kernel/Dockerfile
@@ -73,6 +73,7 @@ RUN mkdir /logs \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
     && ln -s /opt/ibm /liberty \
     && useradd -u 1001 -r -g 0 -s /sbin/nologin default \
+    && mkdir -p /config/configDropins/defaults \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
     && chown -R 1001:0 /opt/ibm/docker/docker-server \

--- a/ga/developer/rhel/kernel/docker-server
+++ b/ga/developer/rhel/kernel/docker-server
@@ -36,7 +36,6 @@ then
     XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
 
     # Create the keystore.xml file and place in configDropins
-    mkdir -p $(dirname $keystorePath)
     echo $XML > $keystorePath
   fi
 fi


### PR DESCRIPTION
Move creation of `/config/configDropins/defaults` directory into the Dockerfile instead of `docker-server` script to avoid file permission issues in ICP.