### PR TITLE
Specify correct product version in FROM instructions

### DIFF
--- a/ga/18.0.0.3/centos/Dockerfile
+++ b/ga/18.0.0.3/centos/Dockerfile
@@ -27,9 +27,9 @@ RUN yum makecache fast \
     && rm -rf /var/tmp/yum-*
     
 # Copy IBM Java, WebSphere Liberty and docker-server into the image
-COPY --from=websphere-liberty:kernel /opt/ibm/java /opt/ibm/java
-COPY --from=websphere-liberty:kernel /opt/ibm/wlp /opt/ibm/wlp
-COPY --from=websphere-liberty:kernel /opt/ibm/docker /opt/ibm/docker
+COPY --from=websphere-liberty:18.0.0.3-kernel /opt/ibm/java /opt/ibm/java
+COPY --from=websphere-liberty:18.0.0.3-kernel /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=websphere-liberty:18.0.0.3-kernel /opt/ibm/docker /opt/ibm/docker
 
 
 # Set environment vars and shorcuts

--- a/ga/18.0.0.3/javaee7/Dockerfile
+++ b/ga/18.0.0.3/javaee7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/javaee8/Dockerfile
+++ b/ga/18.0.0.3/javaee8/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/microProfile1/Dockerfile
+++ b/ga/18.0.0.3/microProfile1/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/microProfile2/Dockerfile
+++ b/ga/18.0.0.3/microProfile2/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/springBoot1/Dockerfile
+++ b/ga/18.0.0.3/springBoot1/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/springBoot2/Dockerfile
+++ b/ga/18.0.0.3/springBoot2/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/webProfile6/Dockerfile
+++ b/ga/18.0.0.3/webProfile6/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/webProfile7/Dockerfile
+++ b/ga/18.0.0.3/webProfile7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.3/webProfile8/Dockerfile
+++ b/ga/18.0.0.3/webProfile8/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.3-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/centos/Dockerfile
+++ b/ga/18.0.0.4/centos/Dockerfile
@@ -27,9 +27,9 @@ RUN yum makecache fast \
     && rm -rf /var/tmp/yum-*
     
 # Copy IBM Java, WebSphere Liberty and docker-server into the image
-COPY --from=websphere-liberty:kernel /opt/ibm/java /opt/ibm/java
-COPY --from=websphere-liberty:kernel /opt/ibm/wlp /opt/ibm/wlp
-COPY --from=websphere-liberty:kernel /opt/ibm/docker /opt/ibm/docker
+COPY --from=websphere-liberty:18.0.0.4-kernel /opt/ibm/java /opt/ibm/java
+COPY --from=websphere-liberty:18.0.0.4-kernel /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=websphere-liberty:18.0.0.4-kernel /opt/ibm/docker /opt/ibm/docker
 
 
 # Set environment vars and shorcuts

--- a/ga/18.0.0.4/javaee7/Dockerfile
+++ b/ga/18.0.0.4/javaee7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/javaee8/Dockerfile
+++ b/ga/18.0.0.4/javaee8/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/microProfile1/Dockerfile
+++ b/ga/18.0.0.4/microProfile1/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/microProfile2/Dockerfile
+++ b/ga/18.0.0.4/microProfile2/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/springBoot1/Dockerfile
+++ b/ga/18.0.0.4/springBoot1/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/springBoot2/Dockerfile
+++ b/ga/18.0.0.4/springBoot2/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/webProfile6/Dockerfile
+++ b/ga/18.0.0.4/webProfile6/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/webProfile7/Dockerfile
+++ b/ga/18.0.0.4/webProfile7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/18.0.0.4/webProfile8/Dockerfile
+++ b/ga/18.0.0.4/webProfile8/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:kernel
+FROM websphere-liberty:18.0.0.4-kernel
 
 ARG REPOSITORIES_PROPERTIES=""
 


### PR DESCRIPTION
Fixes #203 

We need to specify the correct product version in the `FROM websphere-liberty:kernel` instruction, to make sure we aren't basing on the wrong version.