### PR TITLE
Specify correct login shell when adding user

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd -u 1001 -r -g 0 -s /sbin/nologin default
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 2018.12.0_0

--- a/ga/18.0.0.3/centos/Dockerfile
+++ b/ga/18.0.0.3/centos/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir /logs \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
     && ln -s /opt/ibm /liberty \
     && mkdir /config/configDropins \
-    && useradd -u 1001 -r -g 0 -s /sbin/nologin default \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
     && chown -R 1001:0 /opt/ibm/docker/docker-server \

--- a/ga/18.0.0.3/kernel/Dockerfile
+++ b/ga/18.0.0.3/kernel/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /licenses/ \
-    && useradd -u 1001 -r -g 0 -s /sbin/nologin default
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default
 
 COPY *.html /licenses/
 

--- a/ga/18.0.0.4/kernel/Dockerfile
+++ b/ga/18.0.0.4/kernel/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /licenses/ \
-    && useradd -u 1001 -r -g 0 -s /sbin/nologin default
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 18.0.0_04


### PR DESCRIPTION
Fixes #213

Need to specify the `/usr/sbin/nologin` because there is no `/sbin/nologin` in the Ubuntu image. 
Although CentOS has both `/sbin/nologin` and `/usr/sbin/nologin`, I think it is better to specify `/usr/sbin/nologin` for consistency.