### PR TITLE
Revert 19.0.0.1 license files to 18.0.0.4 version

### DIFF
--- a/ga/19.0.0.1/kernel/licenses/en.html
+++ b/ga/19.0.0.1/kernel/licenses/en.html
@@ -14,7 +14,7 @@ the Program, the International License Agreement for Non-
 Warranted Programs (Z125-5589-05) applies.<br>
 <br>
 Program Name (Program Number):<br>
-IBM WebSphere Application Server Liberty 19.0.0.1 (5724-J08)<br>
+IBM WebSphere Application Server Liberty 18.0.0.4 (5724-J08)<br>
 <br>
 The following standard terms apply to Licensee's use of the 
 Program.<br>
@@ -157,9 +157,9 @@ change, and distribute the software to anyone and for any purpose. <br>
 An "Install" is an installed copy of the Program on a 
 physical or virtual disk made available to be executed on a computer.<br>
 <br>
-L/N:  L-CTUR-B89R4V<br>
-D/N:  L-CTUR-B89R4V<br>
-P/N:  L-CTUR-B89R4V<br>
+L/N:  L-CTUR-B4WNHE<br>
+D/N:  L-CTUR-B4WNHE<br>
+P/N:  L-CTUR-B4WNHE<br>
 <br>
 <br>
 International License Agreement for Non-Warranted Programs<br>

--- a/ga/19.0.0.1/kernel/licenses/non_ibm_license.html
+++ b/ga/19.0.0.1/kernel/licenses/non_ibm_license.html
@@ -6,7 +6,7 @@
 <BODY>
 TERMS AND CONDITIONS FOR SEPARATELY LICENSED CODE<br>
 <br>
-IBM WebSphere Application Server Liberty 19.0.0.1<br>
+IBM WebSphere Application Server Liberty 18.0.0.4<br>
 <br>
 The IBM license agreement and any applicable information on 
 the web<br>
@@ -49,8 +49,8 @@ found in /usr/share/doc/${package}/copyright<br>
 -------------------------------------------------------------------------------------------------------------------------------<br>
 ==================================================================================<br>
 <br>
-L/N:  L-CTUR-B89R4V<br>
-D/N:  L-CTUR-B89R4V<br>
-P/N:  L-CTUR-B89R4V<br>
+L/N:  L-CTUR-B4WNHE<br>
+D/N:  L-CTUR-B4WNHE<br>
+P/N:  L-CTUR-B4WNHE<br>
 ﻿</BODY>
 </HTML>


### PR DESCRIPTION
The Liberty 19.0.0.1 product was shipped with the 18.0.0.4 license files except for notices.html.  Not totally sure why but I'm updating the Docker images to match.