### PR TITLE
Updating permissions for server cache

### DIFF
--- a/ga/18.0.0.3/javaee7/Dockerfile
+++ b/ga/18.0.0.3/javaee7/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015,2018.
+# (C) Copyright IBM Corporation 2015,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.3/javaee8/Dockerfile
+++ b/ga/18.0.0.3/javaee8/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.3/kernel/Dockerfile
+++ b/ga/18.0.0.3/kernel/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015,2018.
+# (C) Copyright IBM Corporation 2015,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,6 +77,10 @@ RUN mkdir /logs \
     && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    JVM_ARGS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/18.0.0.3/microProfile1/Dockerfile
+++ b/ga/18.0.0.3/microProfile1/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.3/microProfile2/Dockerfile
+++ b/ga/18.0.0.3/microProfile2/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.3/springBoot1/Dockerfile
+++ b/ga/18.0.0.3/springBoot1/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.3/springBoot2/Dockerfile
+++ b/ga/18.0.0.3/springBoot2/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.3/webProfile7/Dockerfile
+++ b/ga/18.0.0.3/webProfile7/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015,2018.
+# (C) Copyright IBM Corporation 2015,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.3/webProfile8/Dockerfile
+++ b/ga/18.0.0.3/webProfile8/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.4/javaee7/Dockerfile
+++ b/ga/18.0.0.4/javaee7/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015,2018.
+# (C) Copyright IBM Corporation 2015,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.4/javaee8/Dockerfile
+++ b/ga/18.0.0.4/javaee8/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.4/kernel/Dockerfile
+++ b/ga/18.0.0.4/kernel/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015,2018.
+# (C) Copyright IBM Corporation 2015,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,6 +77,10 @@ RUN mkdir /logs \
     && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    JVM_ARGS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/18.0.0.4/microProfile1/Dockerfile
+++ b/ga/18.0.0.4/microProfile1/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.4/microProfile2/Dockerfile
+++ b/ga/18.0.0.4/microProfile2/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.4/oidcProvider/Dockerfile
+++ b/ga/18.0.0.4/oidcProvider/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,4 +30,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/18.0.0.4/springBoot1/Dockerfile
+++ b/ga/18.0.0.4/springBoot1/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.4/springBoot2/Dockerfile
+++ b/ga/18.0.0.4/springBoot2/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.4/webProfile7/Dockerfile
+++ b/ga/18.0.0.4/webProfile7/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2015,2018.
+# (C) Copyright IBM Corporation 2015,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/18.0.0.4/webProfile8/Dockerfile
+++ b/ga/18.0.0.4/webProfile8/Dockerfile
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2018.
+# (C) Copyright IBM Corporation 2018,2019.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/19.0.0.1/javaee7/Dockerfile
+++ b/ga/19.0.0.1/javaee7/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/19.0.0.1/javaee8/Dockerfile
+++ b/ga/19.0.0.1/javaee8/Dockerfile
@@ -28,4 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
+

--- a/ga/19.0.0.1/kernel/Dockerfile
+++ b/ga/19.0.0.1/kernel/Dockerfile
@@ -24,8 +24,10 @@ RUN apt-get update \
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_01
-ARG LIBERTY_URL
+
+ARG LIBERTY_URL 
 ARG DOWNLOAD_OPTIONS=""
+
 RUN LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
     && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \
@@ -41,7 +43,7 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output 
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -77,6 +79,10 @@ RUN mkdir /logs \
     && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    JVM_ARGS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/19.0.0.1/microProfile1/Dockerfile
+++ b/ga/19.0.0.1/microProfile1/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/19.0.0.1/microProfile2/Dockerfile
+++ b/ga/19.0.0.1/microProfile2/Dockerfile
@@ -28,4 +28,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/19.0.0.1/oidcProvider/Dockerfile
+++ b/ga/19.0.0.1/oidcProvider/Dockerfile
@@ -30,4 +30,4 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*

--- a/ga/19.0.0.1/springBoot1/Dockerfile
+++ b/ga/19.0.0.1/springBoot1/Dockerfile
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/19.0.0.1/springBoot2/Dockerfile
+++ b/ga/19.0.0.1/springBoot2/Dockerfile
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/19.0.0.1/webProfile7/Dockerfile
+++ b/ga/19.0.0.1/webProfile7/Dockerfile
@@ -28,5 +28,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 

--- a/ga/19.0.0.1/webProfile8/Dockerfile
+++ b/ga/19.0.0.1/webProfile8/Dockerfile
@@ -27,5 +27,5 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
 
 COPY server.xml /config/
 
-RUN server start && server stop && rm -rf /output/resources/security/ /logs/*
+RUN server start && server stop && rm -rf /output/resources/security/ /logs/* && chmod -R g+rwx /opt/ibm/wlp/output/*
 


### PR DESCRIPTION
Our current images cannot run as-is with users other than `1001`, which is an issue for platforms such as OpenShift Online.  

The main issue is with the server warmup, because classes are cached as user `1001`, but access by another random user.  Very easy to reproduce, just run `docker run -u 13001 websphere-liberty` and see the crash.

The fix:
- applies the right permissions to folders such as `workarea` can be access by another user in the root group
- use the appropriate shared class setting so that other users can access the cache

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>