### PR TITLE
Move lib.index.cache directory work to springBoot files

### DIFF
--- a/ga/18.0.0.3/kernel/Dockerfile
+++ b/ga/18.0.0.3/kernel/Dockerfile
@@ -55,7 +55,6 @@ COPY docker-server /opt/ibm/docker/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -74,8 +73,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/18.0.0.3/springBoot1/Dockerfile
+++ b/ga/18.0.0.3/springBoot1/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.3/springBoot2/Dockerfile
+++ b/ga/18.0.0.3/springBoot2/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.4/kernel/Dockerfile
+++ b/ga/18.0.0.4/kernel/Dockerfile
@@ -54,7 +54,6 @@ COPY licenses/ /licenses/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -74,8 +73,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/18.0.0.4/springBoot1/Dockerfile
+++ b/ga/18.0.0.4/springBoot1/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.4/springBoot2/Dockerfile
+++ b/ga/18.0.0.4/springBoot2/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/19.0.0.3/kernel/Dockerfile
+++ b/ga/19.0.0.3/kernel/Dockerfile
@@ -56,7 +56,6 @@ COPY licenses/ /licenses/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -76,8 +75,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/19.0.0.3/springBoot1/Dockerfile
+++ b/ga/19.0.0.3/springBoot1/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/19.0.0.3/springBoot2/Dockerfile
+++ b/ga/19.0.0.3/springBoot2/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs


### PR DESCRIPTION
Tom Watson and Anjum Fatima pointed out that there is a problem with the kernel Dockerfile creating the /lib.index.cache directory when it should really be a symlink to /opt/ibm/wlp/usr/shared/resources/lib.index.cache.

Since that directory is only used by the springBoot images, we are moving the work related to that directory into the springBoot Dockerfiles.