### PR TITLE
Set up lib.index.cache dir in kernel images

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -44,7 +44,6 @@ COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -63,8 +62,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -44,6 +44,7 @@ COPY server.xml /opt/ibm/wlp/usr/servers/defaultServer/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -51,6 +52,7 @@ RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \

--- a/ga/18.0.0.3/centos/Dockerfile
+++ b/ga/18.0.0.3/centos/Dockerfile
@@ -43,9 +43,11 @@ RUN installUtility install --acceptLicense microProfile-1.4 \
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir /config/configDropins \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
     && chown -R 1001:0 /config \
@@ -54,6 +56,8 @@ RUN mkdir /logs \
     && chmod -R g+rwx /opt/ibm/docker/docker-server \
     && chown -R 1001:0 /opt/ibm/wlp/usr/servers/defaultServer \
     && chmod -R g+rw /opt/ibm/wlp/usr/servers/defaultServer \
+    && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+    && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && chown -R 1001:0 /opt/ibm/wlp/output \
     && chmod -R g+rw /opt/ibm/wlp/output \
     && chown -R 1001:0 /logs \

--- a/ga/18.0.0.3/kernel/Dockerfile
+++ b/ga/18.0.0.3/kernel/Dockerfile
@@ -55,6 +55,7 @@ COPY docker-server /opt/ibm/docker/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
+    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -75,6 +76,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /lib.index.cache \
+    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/18.0.0.3/kernel/Dockerfile
+++ b/ga/18.0.0.3/kernel/Dockerfile
@@ -55,7 +55,7 @@ COPY docker-server /opt/ibm/docker/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -63,6 +63,7 @@ RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \
     && chown -R 1001:0 /config \
     && chmod -R g+rw /config \
@@ -76,8 +77,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/18.0.0.3/springBoot1/Dockerfile
+++ b/ga/18.0.0.3/springBoot1/Dockerfile
@@ -21,8 +21,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.3/springBoot1/Dockerfile
+++ b/ga/18.0.0.3/springBoot1/Dockerfile
@@ -20,8 +20,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
-  && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
 

--- a/ga/18.0.0.3/springBoot2/Dockerfile
+++ b/ga/18.0.0.3/springBoot2/Dockerfile
@@ -21,8 +21,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.3/springBoot2/Dockerfile
+++ b/ga/18.0.0.3/springBoot2/Dockerfile
@@ -20,8 +20,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
-  && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
 

--- a/ga/18.0.0.4/centos/Dockerfile
+++ b/ga/18.0.0.4/centos/Dockerfile
@@ -43,9 +43,11 @@ RUN installUtility install --acceptLicense microProfile-1.4 \
 
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config  \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir /config/configDropins \
     && useradd -u 1001 -r -g 0 -s /sbin/nologin default \
     && chown -R 1001:0 /config \
@@ -54,6 +56,8 @@ RUN mkdir /logs \
     && chmod -R g+rwx /opt/ibm/docker/docker-server \
     && chown -R 1001:0 /opt/ibm/wlp/usr/servers/defaultServer \
     && chmod -R g+rw /opt/ibm/wlp/usr/servers/defaultServer \
+    && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+    && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && chown -R 1001:0 /opt/ibm/wlp/output \
     && chmod -R g+rw /opt/ibm/wlp/output \
     && chown -R 1001:0 /logs \

--- a/ga/18.0.0.4/kernel/Dockerfile
+++ b/ga/18.0.0.4/kernel/Dockerfile
@@ -54,7 +54,7 @@ COPY licenses/ /licenses/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -62,6 +62,7 @@ RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
     && chown -R 1001:0 /config \
@@ -76,8 +77,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/18.0.0.4/kernel/Dockerfile
+++ b/ga/18.0.0.4/kernel/Dockerfile
@@ -54,6 +54,7 @@ COPY licenses/ /licenses/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
+    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -75,6 +76,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /lib.index.cache \
+    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/18.0.0.4/springBoot1/Dockerfile
+++ b/ga/18.0.0.4/springBoot1/Dockerfile
@@ -21,8 +21,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.4/springBoot1/Dockerfile
+++ b/ga/18.0.0.4/springBoot1/Dockerfile
@@ -20,8 +20,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
-  && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
 

--- a/ga/18.0.0.4/springBoot2/Dockerfile
+++ b/ga/18.0.0.4/springBoot2/Dockerfile
@@ -21,8 +21,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/18.0.0.4/springBoot2/Dockerfile
+++ b/ga/18.0.0.4/springBoot2/Dockerfile
@@ -20,8 +20,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
-  && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
 

--- a/ga/19.0.0.3/kernel/Dockerfile
+++ b/ga/19.0.0.3/kernel/Dockerfile
@@ -56,7 +56,7 @@ COPY licenses/ /licenses/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -64,6 +64,7 @@ RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
     && chown -R 1001:0 /config \
@@ -78,8 +79,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/19.0.0.3/kernel/Dockerfile
+++ b/ga/19.0.0.3/kernel/Dockerfile
@@ -56,6 +56,7 @@ COPY licenses/ /licenses/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
+    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -77,6 +78,8 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /lib.index.cache \
+    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/19.0.0.3/kernel/Dockerfile.centos
+++ b/ga/19.0.0.3/kernel/Dockerfile.centos
@@ -57,7 +57,6 @@ COPY helpers/ /opt/ibm/helpers/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
-    && mkdir /lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -79,8 +78,6 @@ RUN mkdir /logs \
     && chmod -R g+rw /logs \
     && chown -R 1001:0 /etc/wlp \
     && chmod -R g+rw /etc/wlp \
-    && chown -R 1001:0 /lib.index.cache \
-    && chmod -R g+rw /lib.index.cache \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
 

--- a/ga/19.0.0.3/kernel/Dockerfile.centos
+++ b/ga/19.0.0.3/kernel/Dockerfile.centos
@@ -57,6 +57,7 @@ COPY helpers/ /opt/ibm/helpers/
 # Create symlinks && set permissions for non-root user
 RUN mkdir /logs \
     && mkdir /etc/wlp \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
     && mkdir -p /home/default \
     && mkdir /output \
     && chmod -t /output \
@@ -64,6 +65,7 @@ RUN mkdir /logs \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
     && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \
     && mkdir -p /config/configDropins/overrides \
     && chown -R 1001:0 /config \

--- a/ga/19.0.0.3/springBoot1/Dockerfile
+++ b/ga/19.0.0.3/springBoot1/Dockerfile
@@ -21,8 +21,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/19.0.0.3/springBoot1/Dockerfile
+++ b/ga/19.0.0.3/springBoot1/Dockerfile
@@ -20,8 +20,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
-  && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
 

--- a/ga/19.0.0.3/springBoot2/Dockerfile
+++ b/ga/19.0.0.3/springBoot2/Dockerfile
@@ -21,8 +21,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
   && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs

--- a/ga/19.0.0.3/springBoot2/Dockerfile
+++ b/ga/19.0.0.3/springBoot2/Dockerfile
@@ -20,8 +20,6 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
-  && mkdir /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
-  && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs
 


### PR DESCRIPTION
The springBoot1 and 2 builds are breaking because of the change under #243. The /lib.index.cache directory needs to be created as the root user due to permissions issues, so we need to set it up in the kernel images which will therefore get it into the springBoot images where it is needed.