### PR TITLE
Modified configure.sh to ignore rc=22

### DIFF
--- a/ga/18.0.0.4/kernel/helpers/build/configure.sh
+++ b/ga/18.0.0.4/kernel/helpers/build/configure.sh
@@ -75,4 +75,4 @@ fi
 
 
 # Install needed features
-installUtility install --acceptLicense defaultServer
+installUtility install --acceptLicense defaultServer || if [ $? -ne 22 ]; then exit $?; fi

--- a/ga/19.0.0.3/kernel/helpers/build/configure.sh
+++ b/ga/19.0.0.3/kernel/helpers/build/configure.sh
@@ -75,4 +75,4 @@ fi
 
 
 # Install needed features
-installUtility install --acceptLicense defaultServer
+installUtility install --acceptLicense defaultServer || if [ $? -ne 22 ]; then exit $?; fi


### PR DESCRIPTION
`installUtility` will often return code 22 when a user feature is already installed. After changing the scripts, I tested the changes locally and now the output looks like this
```
Preparing assets for installation. This process might take several minutes to complete.
CWWKF1250I: The following assets already exist: [usr:opentracingZipkin-0.31]. They will not be reinstalled. To modify an existing feature, you must manually uninstall it first.
+ '[' 22 -ne 22 ']'
Removing intermediate container 5c4b9018c913
 ---> 8f0360fd02a5
Successfully built 8f0360fd02a5
```