### PR TITLE
Add openssl to Dockerfile

### DIFF
--- a/ga/19.0.0.3/kernel/Dockerfile
+++ b/ga/19.0.0.3/kernel/Dockerfile
@@ -23,7 +23,7 @@ ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip \
+    && apt-get install -y --no-install-recommends unzip openssl\
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /licenses/ \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \

--- a/ga/19.0.0.4/kernel/Dockerfile
+++ b/ga/19.0.0.4/kernel/Dockerfile
@@ -23,7 +23,7 @@ ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip \
+    && apt-get install -y --no-install-recommends unzip openssl \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /licenses/ \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \


### PR DESCRIPTION
This PR is for issue #224 
Proactively added `openssl` to the Dockerfile.