### PR TITLE
Install wget before uninstall it

### DIFF
--- a/ga/19.0.0.3/kernel/Dockerfile
+++ b/ga/19.0.0.3/kernel/Dockerfile
@@ -23,7 +23,7 @@ ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip openssl\
+    && apt-get install -y --no-install-recommends unzip wget openssl\
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /licenses/ \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \

--- a/ga/19.0.0.4/kernel/Dockerfile
+++ b/ga/19.0.0.4/kernel/Dockerfile
@@ -23,7 +23,7 @@ ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip openssl \
+    && apt-get install -y --no-install-recommends unzip wget openssl \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /licenses/ \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \

--- a/ga/19.0.0.4/kernel/Dockerfile.ubi-min
+++ b/ga/19.0.0.4/kernel/Dockerfile.ubi-min
@@ -24,7 +24,7 @@ ARG DOWNLOAD_OPTIONS=""
 
 # Operating System update
 RUN microdnf update -y \
-    && microdnf -y install shadow-utils unzip \
+    && microdnf -y install shadow-utils unzip wget \
     && microdnf clean all \
     && mkdir /licenses \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \


### PR DESCRIPTION
This PR is related to issue #247
Modified the Dockerfile to install wget which is already installed in IBM Java image and will be uninstalld after use.
In this way, the size can be reduced when wget is removed from the IBM Java image in the future.