### PR TITLE
Fix issues with images upgrading to 19.0.0.5

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -14,7 +14,11 @@
 
 FROM ibmjava:8-jre
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.revision="cl190520190522-2227"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \

--- a/ga/18.0.0.4/centos/Dockerfile
+++ b/ga/18.0.0.4/centos/Dockerfile
@@ -14,7 +14,12 @@
 
 FROM centos:latest
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="18.0.0.4" \
+      org.opencontainers.image.revision="cl180420181121-0300"
 
 # Operating System update
 RUN yum makecache fast \

--- a/ga/18.0.0.4/kernel/Dockerfile
+++ b/ga/18.0.0.4/kernel/Dockerfile
@@ -14,7 +14,12 @@
 
 FROM ibmjava:8-jre
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="18.0.0.4" \
+      org.opencontainers.image.revision="cl180420181121-0300"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \

--- a/ga/18.0.0.4/kernel/helpers/build/configure.sh
+++ b/ga/18.0.0.4/kernel/helpers/build/configure.sh
@@ -79,6 +79,6 @@ installUtility install --acceptLicense defaultServer || if [ $? -ne 22 ]; then e
 #Make sure that group write permissions are set correctly after installing new features 
 find /opt/ibm/wlp -perm -g=w -print0 | xargs -0 -r chmod -R g+rw
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
+/opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
 #Make folder executable for a group
 find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx

--- a/ga/19.0.0.3/kernel/Dockerfile
+++ b/ga/19.0.0.3/kernel/Dockerfile
@@ -14,7 +14,12 @@
 
 FROM ibmjava:8-jre
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="19.0.0.3" \
+      org.opencontainers.image.revision="cl190320190321-1636"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_03

--- a/ga/19.0.0.3/kernel/Dockerfile.centos
+++ b/ga/19.0.0.3/kernel/Dockerfile.centos
@@ -14,7 +14,12 @@
 
 FROM ibmjava:8-jre
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="19.0.0.3" \
+      org.opencontainers.image.revision="cl190320190321-1636"
 
 RUN yum makecache fast \
     && yum -y install unzip \

--- a/ga/19.0.0.3/kernel/helpers/build/configure.sh
+++ b/ga/19.0.0.3/kernel/helpers/build/configure.sh
@@ -83,6 +83,6 @@ find /opt/ibm/fixes -type f -name "*.jar"  -print0 | sort -z | xargs -0 -n 1 -r 
 #Make sure that group write permissions are set correctly after installing new features 
 find /opt/ibm/wlp -perm -g=w -print0 | xargs -0 -r chmod -R g+rw
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
+/opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
 #Make folder executable for a group
 find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx

--- a/ga/19.0.0.5/kernel/Dockerfile
+++ b/ga/19.0.0.5/kernel/Dockerfile
@@ -14,7 +14,12 @@
 
 FROM ibmjava:8-jre
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="19.0.0.5" \
+      org.opencontainers.image.revision="cl190520190522-2227"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_05

--- a/ga/19.0.0.5/kernel/Dockerfile.centos
+++ b/ga/19.0.0.5/kernel/Dockerfile.centos
@@ -14,7 +14,12 @@
 
 FROM ibmjava:8-jre
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="19.0.0.5" \
+      org.opencontainers.image.revision="cl190520190522-2227"
 
 RUN yum makecache fast \
     && yum -y install unzip \

--- a/ga/19.0.0.5/kernel/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/kernel/Dockerfile.ubi-min
@@ -14,7 +14,12 @@
 
 FROM ibmjava:8-ibmsfj-ubi-min
 
-LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)"
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Andy Naumann" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="19.0.0.5" \
+      org.opencontainers.image.revision="cl190520190522-2227"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_05

--- a/ga/19.0.0.5/kernel/helpers/build/configure.sh
+++ b/ga/19.0.0.5/kernel/helpers/build/configure.sh
@@ -83,6 +83,6 @@ find /opt/ibm/fixes -type f -name "*.jar"  -print0 | sort -z | xargs -0 -n 1 -r 
 #Make sure that group write permissions are set correctly after installing new features 
 find /opt/ibm/wlp -perm -g=w -print0 | xargs -0 -r chmod -R g+rw
 # Server start/stop to populate the /output/workarea and make subsequent server starts faster
-RUN server start && server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
+/opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop && rm -rf /output/resources/security/ /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
 #Make folder executable for a group
 find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx


### PR DESCRIPTION
Fixing issues pointed out under https://github.com/docker-library/official-images/pull/5951 and docker-library/official-images#5950

    Removing --update from the apk add --no-cache calls.
    Updating image labels to comply with https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md
    Removing bad RUN in configure.sh server start/stop line.
