### PR TITLE
Fixing permissions

### DIFF
--- a/ga/18.0.0.4/javaee7/Dockerfile
+++ b/ga/18.0.0.4/javaee7/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 sessionCache-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/javaee8/Dockerfile
+++ b/ga/18.0.0.4/javaee8/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
     appSecurityClient-1.0 javaee-8.0 javaeeClient-8.0 openidConnectClient-1.0 monitor-1.0 microProfile-2.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/microProfile1/Dockerfile
+++ b/ga/18.0.0.4/microProfile1/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
      requestTiming-1.0 restConnector-2.0 sessionCache-1.0 sessionDatabase-1.0 \
      ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/microProfile2/Dockerfile
+++ b/ga/18.0.0.4/microProfile2/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 \
     webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/oidcProvider/Dockerfile
+++ b/ga/18.0.0.4/oidcProvider/Dockerfile
@@ -26,6 +26,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     socialLogin-1.0 \
     openidConnectClient-1.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/springBoot1/Dockerfile
+++ b/ga/18.0.0.4/springBoot1/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/springBoot2/Dockerfile
+++ b/ga/18.0.0.4/springBoot2/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/webProfile7/Dockerfile
+++ b/ga/18.0.0.4/webProfile7/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/18.0.0.4/webProfile8/Dockerfile
+++ b/ga/18.0.0.4/webProfile8/Dockerfile
@@ -23,6 +23,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     localConnector-1.0 monitor-1.0 requestTiming-1.0 restConnector-2.0 sessionCache-1.0 \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/javaee7/Dockerfile
+++ b/ga/19.0.0.3/javaee7/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 sessionCache-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/javaee8/Dockerfile
+++ b/ga/19.0.0.3/javaee8/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
     appSecurityClient-1.0 javaee-8.0 javaeeClient-8.0 openidConnectClient-1.0 monitor-1.0 microProfile-2.0 microProfile-2.1 microProfile-2.2 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/microProfile1/Dockerfile
+++ b/ga/19.0.0.3/microProfile1/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
      requestTiming-1.0 restConnector-2.0 sessionCache-1.0 sessionDatabase-1.0 \
      ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/microProfile2/Dockerfile
+++ b/ga/19.0.0.3/microProfile2/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 \
     webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/oidcProvider/Dockerfile
+++ b/ga/19.0.0.3/oidcProvider/Dockerfile
@@ -26,6 +26,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     socialLogin-1.0 \
     openidConnectClient-1.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/springBoot1/Dockerfile
+++ b/ga/19.0.0.3/springBoot1/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/springBoot2/Dockerfile
+++ b/ga/19.0.0.3/springBoot2/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/webProfile7/Dockerfile
+++ b/ga/19.0.0.3/webProfile7/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.3/webProfile8/Dockerfile
+++ b/ga/19.0.0.3/webProfile8/Dockerfile
@@ -23,6 +23,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     localConnector-1.0 monitor-1.0 requestTiming-1.0 restConnector-2.0 sessionCache-1.0 \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/javaee7/Dockerfile
+++ b/ga/19.0.0.5/javaee7/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 sessionCache-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/javaee7/Dockerfile.java11
+++ b/ga/19.0.0.5/javaee7/Dockerfile.java11
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 sessionCache-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/javaee7/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/javaee7/Dockerfile.ubi-min
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 sessionCache-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 appSecurityClient-1.0 javaee-7.0 javaeeClient-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/javaee8/Dockerfile
+++ b/ga/19.0.0.5/javaee8/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
     appSecurityClient-1.0 javaee-8.0 javaeeClient-8.0 openidConnectClient-1.0 monitor-1.0 microProfile-2.0 microProfile-2.1 microProfile-2.2 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/javaee8/Dockerfile.java11
+++ b/ga/19.0.0.5/javaee8/Dockerfile.java11
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
     appSecurityClient-1.0 javaee-8.0 javaeeClient-8.0 openidConnectClient-1.0 monitor-1.0 microProfile-2.0 microProfile-2.1 microProfile-2.2 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/javaee8/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/javaee8/Dockerfile.ubi-min
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
     appSecurityClient-1.0 javaee-8.0 javaeeClient-8.0 openidConnectClient-1.0 monitor-1.0 microProfile-2.0 microProfile-2.1 microProfile-2.2 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/microProfile1/Dockerfile
+++ b/ga/19.0.0.5/microProfile1/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
      requestTiming-1.0 restConnector-2.0 sessionCache-1.0 sessionDatabase-1.0 \
      ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/microProfile1/Dockerfile.java11
+++ b/ga/19.0.0.5/microProfile1/Dockerfile.java11
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
      requestTiming-1.0 restConnector-2.0 sessionCache-1.0 sessionDatabase-1.0 \
      ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/microProfile1/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/microProfile1/Dockerfile.ubi-min
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
      requestTiming-1.0 restConnector-2.0 sessionCache-1.0 sessionDatabase-1.0 \
      ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/microProfile2/Dockerfile
+++ b/ga/19.0.0.5/microProfile2/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 \
     webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/microProfile2/Dockerfile.java11
+++ b/ga/19.0.0.5/microProfile2/Dockerfile.java11
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 \
     webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/microProfile2/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/microProfile2/Dockerfile.ubi-min
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 \
     webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/oidcProvider/Dockerfile
+++ b/ga/19.0.0.5/oidcProvider/Dockerfile
@@ -26,6 +26,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     socialLogin-1.0 \
     openidConnectClient-1.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/oidcProvider/Dockerfile.java11
+++ b/ga/19.0.0.5/oidcProvider/Dockerfile.java11
@@ -26,6 +26,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     socialLogin-1.0 \
     openidConnectClient-1.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/springBoot1/Dockerfile
+++ b/ga/19.0.0.5/springBoot1/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/springBoot1/Dockerfile.java11
+++ b/ga/19.0.0.5/springBoot1/Dockerfile.java11
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/springBoot1/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/springBoot1/Dockerfile.ubi-min
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-1.5 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/springBoot2/Dockerfile
+++ b/ga/19.0.0.5/springBoot2/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/springBoot2/Dockerfile.java11
+++ b/ga/19.0.0.5/springBoot2/Dockerfile.java11
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/springBoot2/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/springBoot2/Dockerfile.ubi-min
@@ -21,6 +21,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense \
     jsp-2.3 servlet-4.0 springBoot-2.0 transportSecurity-1.0 webSocket-1.1 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/webProfile7/Dockerfile
+++ b/ga/19.0.0.5/webProfile7/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/webProfile7/Dockerfile.java11
+++ b/ga/19.0.0.5/webProfile7/Dockerfile.java11
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/webProfile7/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/webProfile7/Dockerfile.ubi-min
@@ -24,6 +24,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     requestTiming-1.0 restConnector-2.0 sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 \
     webCache-1.0 webProfile-7.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/webProfile8/Dockerfile
+++ b/ga/19.0.0.5/webProfile8/Dockerfile
@@ -23,6 +23,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     localConnector-1.0 monitor-1.0 requestTiming-1.0 restConnector-2.0 sessionCache-1.0 \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/webProfile8/Dockerfile.java11
+++ b/ga/19.0.0.5/webProfile8/Dockerfile.java11
@@ -23,6 +23,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     localConnector-1.0 monitor-1.0 requestTiming-1.0 restConnector-2.0 sessionCache-1.0 \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/

--- a/ga/19.0.0.5/webProfile8/Dockerfile.ubi-min
+++ b/ga/19.0.0.5/webProfile8/Dockerfile.ubi-min
@@ -23,6 +23,7 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
     localConnector-1.0 monitor-1.0 requestTiming-1.0 restConnector-2.0 sessionCache-1.0 \
     sessionDatabase-1.0 ssl-1.0 transportSecurity-1.0 webCache-1.0 webProfile-8.0 \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
-  && rm -rf /output/workarea /output/logs
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/


### PR DESCRIPTION
A regression was introduced when we moved the warmup code into `configure.sh`:  if a customer was NOT calling `configure.sh` and they were running on OpenShift they would now see messages such as this:

```
JVMSHRC226E Error opening shared class cache file 
JVMSHRC336E Port layer error code = -102
JVMSHRC337E Platform error message: Permission denied
JVMSHRC686I Failed to startup shared class cache. Continue without using it as -Xshareclasses:nonfatal is specified
```

And the container startup would fail.

The key is this command:  `chmod -R g+rwx /opt/ibm/wlp/output/*`, which ensures the cached workarea created by `installUtility` has the correct permissions.