### PR TITLE
Add transportSecurity feature to kernel image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,9 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Monitor the server runtime environment and application metrics by using Liberty features `mpMetrics-1.1` (implements [Microprofile Metrics](https://microprofile.io/project/eclipse/microprofile-metrics)) and `monitor-1.0`.
   *  XML Snippet Location: [mp-monitoring.xml](ga/latest/kernel/helpers/build/configuration_snippets/mp-monitoring.xml)
   *  Note: With this option, `/metrics` endpoint is configured without authentication to support the environments that do not yet support scraping secured endpoints.
-* `TLS`
+* `TLS` or `SSL` (SSL is being deprecated)
   *  Decription: Enable Transport Security in Liberty by adding the `transportSecurity-1.0` feature (includes support for SSL).
-  *  XML Snippet Location:  [transportSecurity.xml](ga/latest/kernel/helpers/build/configuration_snippets/transportSecurity.xml).
-* `SSL`
-  *  Decription: Enable SSL in Liberty by adding the `ssl-1.0` feature.
-  *  XML Snippet Location:  [ssl.xml](ga/latest/kernel/helpers/build/configuration_snippets/ssl.xml).
+  *  XML Snippet Location:  [keystore.xml](ga/latest/kernel/helpers/build/configuration_snippets/keystore.xml).
 * `IIOP_ENDPOINT`
   *  Decription: Add configuration properties for an IIOP endpoint.
   *  XML Snippet Location: [iiop-ssl-endpoint.xml](ga/latest/kernel/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml) when SSL is enabled. Otherwise, [iiop-endpoint.xml](ga/latest/kernel/helpers/build/configuration_snippets/iiop-endpoint.xml).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Monitor the server runtime environment and application metrics by using Liberty features `mpMetrics-1.1` (implements [Microprofile Metrics](https://microprofile.io/project/eclipse/microprofile-metrics)) and `monitor-1.0`.
   *  XML Snippet Location: [mp-monitoring.xml](ga/latest/kernel/helpers/build/configuration_snippets/mp-monitoring.xml)
   *  Note: With this option, `/metrics` endpoint is configured without authentication to support the environments that do not yet support scraping secured endpoints.
+* `TLS`
+  *  Decription: Enable Transport Security in Liberty by adding the `transportSecurity-1.0` feature (includes support for SSL).
+  *  XML Snippet Location:  [transportSecurity.xml](ga/latest/kernel/helpers/build/configuration_snippets/transportSecurity.xml).
 * `SSL`
   *  Decription: Enable SSL in Liberty by adding the `ssl-1.0` feature.
   *  XML Snippet Location:  [ssl.xml](ga/latest/kernel/helpers/build/configuration_snippets/ssl.xml).

--- a/ga/latest/kernel/helpers/build/configuration_snippets/transportSecurity.xml
+++ b/ga/latest/kernel/helpers/build/configuration_snippets/transportSecurity.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+</server>

--- a/ga/latest/kernel/helpers/build/configuration_snippets/transportSecurity.xml
+++ b/ga/latest/kernel/helpers/build/configuration_snippets/transportSecurity.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<server>
-    <featureManager>
-        <feature>transportSecurity-1.0</feature>
-    </featureManager>
-</server>

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -23,6 +23,11 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
+# TLS
+if [ "$TLS" == "true" ]; then
+  cp $SNIPPETS_SOURCE/transportSecurity.xml $SNIPPETS_TARGET/transportSecurity.xml
+fi
+
 # SSL
 if [ "$SSL" == "true" ]; then
   cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
@@ -40,7 +45,7 @@ fi
 
 # HTTP Endpoint
 if [ "$HTTP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
@@ -57,7 +62,7 @@ fi
 
 # IIOP Endpoint
 if [ "$IIOP_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
@@ -66,7 +71,7 @@ fi
 
 # JMS Endpoint
 if [ "$JMS_ENDPOINT" == "true" ]; then
-  if [ "$SSL" == "true" ]; then
+  if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]; then
     cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
   else
     cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -23,16 +23,6 @@ if [ "$MP_MONITORING" == "true" ]; then
   cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
 fi
 
-# TLS
-if [ "$TLS" == "true" ]; then
-  cp $SNIPPETS_SOURCE/transportSecurity.xml $SNIPPETS_TARGET/transportSecurity.xml
-fi
-
-# SSL
-if [ "$SSL" == "true" ]; then
-  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
-fi
-
 # OpenIdConnect Client
 if [ "$OIDC" == "true" ]  || [ "$OIDC_CONFIG" == "true" ]
 then


### PR DESCRIPTION
Added the transportSecurity.xml file into the configuration_snippets folder.

The transportSecurity feature includes the ssl feature thus superseding it.

https://www.ibm.com/support/knowledgecenter/en/SSAW57_liberty/com.ibm.websphere.liberty.autogen.nd.doc/ae/rwlp_feature_transportSecurity-1.0.html