### PR TITLE
Add keystore file to defaults instead of overrides

### DIFF
--- a/ga/latest/kernel/helpers/build/configuration_snippets/keystore.xml
+++ b/ga/latest/kernel/helpers/build/configuration_snippets/keystore.xml
@@ -1,6 +1,3 @@
 <server description="Default Server">
-    <featureManager>
-        <feature>transportSecurity-1.0</feature>
-    </featureManager>
     <keyStore id="defaultKeyStore" password="REPLACE" />
 </server>

--- a/ga/latest/kernel/helpers/build/configuration_snippets/tls.xml
+++ b/ga/latest/kernel/helpers/build/configuration_snippets/tls.xml
@@ -1,0 +1,5 @@
+<server description="Default Server">
+    <featureManager>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+</server>

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -8,6 +8,7 @@ SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
 
 SNIPPETS_SOURCE=/opt/ibm/helpers/build/configuration_snippets
 SNIPPETS_TARGET=/config/configDropins/overrides
+SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
 mkdir -p ${SNIPPETS_TARGET}
 
 
@@ -69,17 +70,21 @@ if [ "$JMS_ENDPOINT" == "true" ]; then
 fi
 
 # Key Store
-keystorePath="$SNIPPETS_TARGET/keystore.xml"
+keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
 if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
 then
-    # Check if the password is set already
-    if [ ! -e $keystorePath ]
-    then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
-      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
-    fi
+  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET/tls.xml
+fi
+
+if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
+then
+  if [ ! -e $keystorePath ]
+  then
+    # Generate the keystore.xml
+    export KEYSTOREPWD=$(openssl rand -base64 32)
+    sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
+  fi
 fi
 
 # Install needed features

--- a/ga/latest/kernel/helpers/runtime/docker-server.sh
+++ b/ga/latest/kernel/helpers/runtime/docker-server.sh
@@ -19,19 +19,25 @@ case "${LICENSE,,}" in
     ;;
 esac
 
-SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
-SNIPPETS_TARGET=/config/configDropins/overrides
+SNIPPETS_SOURCE=/opt/ibm/helpers/build/configuration_snippets
+SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+SNIPPETS_TARGET_OVERRIDES=/config/configDropins/overrides
 
-keystorePath="$SNIPPETS_TARGET/keystore.xml"
+keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
 
 if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+then
+  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET_OVERRIDES/tls.xml
+fi
+
+if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
 then
   if [ ! -e $keystorePath ]
   then
     # Generate the keystore.xml
     export KEYSTOREPWD=$(openssl rand -base64 32)
     sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
-    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
+    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
 fi
 


### PR DESCRIPTION
Make use of defaults folder for keystore.xml snippet, generate it unless TLS and SSL are false
Separate TLS feature into separate snippet 

Fix for #287 