### PR TITLE
Fix Permissions Issue in Travis for UBI Build

### DIFF
--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -38,6 +38,7 @@ RUN microdnf -y install shadow-utils unzip wget findutils \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
     && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
     && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \
     && rm /tmp/wlp.zip \
     && chown -R 1001:0 /opt/ibm/wlp \

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -38,6 +38,7 @@ RUN microdnf -y install shadow-utils unzip wget findutils \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
     && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
     && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \
     && rm /tmp/wlp.zip \
     && chown -R 1001:0 /opt/ibm/wlp \

--- a/ga/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -37,6 +37,7 @@ RUN yum -y install unzip wget \
     && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
     && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
     && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \
     && rm /tmp/wlp.zip \
     && chown -R 1001:0 /opt/ibm/wlp \


### PR DESCRIPTION
- Travis runs into intermittent issues with root's permission to /usr/bin on ppc64le VMs. Likely from some setup issue Travis encounters with this particular architecture.
- Given that the build is already running as root, the added command is redundant in other scenarios.