### PR TITLE
Generate random keystore with /dev/urandom instead of openssl

### DIFF
--- a/ga/19.0.0.12/kernel/helpers/runtime/docker-server.sh
+++ b/ga/19.0.0.12/kernel/helpers/runtime/docker-server.sh
@@ -35,7 +35,7 @@ then
   if [ ! -e $keystorePath ]
   then
     # Generate the keystore.xml
-    export KEYSTOREPWD=$(openssl rand -base64 32)
+    export KEYSTOREPWD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
     sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
     cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi

--- a/ga/latest/kernel/helpers/runtime/docker-server.sh
+++ b/ga/latest/kernel/helpers/runtime/docker-server.sh
@@ -35,7 +35,7 @@ then
   if [ ! -e $keystorePath ]
   then
     # Generate the keystore.xml
-    export KEYSTOREPWD=$(openssl rand -base64 32)
+    export KEYSTOREPWD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
     sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
     cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi


### PR DESCRIPTION
WAS Liberty port of https://github.com/OpenLiberty/ci.docker/pull/131