### PR TITLE
Adding the verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ ARG MP_MONITORING=true
 # Add interim fixes (optional)
 COPY --chown=1001:0  interim-fixes /opt/ibm/fixes/
 
+# Default setting for the verbose option
+ARG VERBOSE=false
+
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh
 ```
@@ -37,7 +40,7 @@ This will result in a Docker image that has your application and configuration p
 
 ## Optional Enterprise Functionality
 
-This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular argument (`ARG`) or environment variable (`ENV`) and calling `RUN configure.sh`.  Each of these options trigger the inclusion of specific configuration via XML snippets, described below:
+This section describes the optional enterprise functionality that can be enabled via the Dockerfile during `build` time, by setting particular argument (`ARG`) or environment variable (`ENV`) and calling `RUN configure.sh`.  Each of these options trigger the inclusion of specific configuration via XML snippets (except for `VERBOSE`), described below:
 
 * `HTTP_ENDPOINT`
   *  Decription: Add configuration properties for an HTTP endpoint.
@@ -69,6 +72,8 @@ This section describes the optional enterprise functionality that can be enabled
 * `HZ_SESSION_CACHE`
   *  Decription: Enable the persistence of HTTP sessions using JCache by adding the `sessionCache-1.0` feature.
   *  XML Snippet Location: [hazelcast-sessioncache.xml](ga/latest/kernel/helpers/build/configuration_snippets/hazelcast-sessioncache.xml)
+*  `VERBOSE`
+  * Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Otherwise, default setting is `false` and `configure.sh` is silenced.
 
 
 ### Logging
@@ -105,6 +110,9 @@ COPY --from=hazelcast/hazelcast --chown=1001:0 /opt/hazelcast/lib/*.jar /opt/ibm
 # Instruct configure.sh to copy the client topology hazelcast.xml
 ARG HZ_SESSION_CACHE=client
 
+# Default setting for the verbose option
+ARG VERBOSE=false
+
 # Instruct configure.sh to copy the embedded topology hazelcast.xml and set the required system property
 #ARG HZ_SESSION_CACHE=embedded
 #ENV JAVA_TOOL_OPTIONS="-Dhazelcast.jcache.provider.type=server ${JAVA_TOOL_OPTIONS}"
@@ -122,6 +130,9 @@ Ensure that all features needed by your applications, apart from the ones that w
 ```dockerfile
 # Add interim fixes (optional)
 COPY --chown=1001:0  interim-fixes /opt/ibm/fixes/
+
+# Default setting for the verbose option
+ARG VERBOSE=false
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh
@@ -158,6 +169,7 @@ You can also set it through Dockerfile
 ```dockerfile
 FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
 ARG FEATURE_REPO_URL=http://wlprepos:8080/19.0.0.x/repo.zip
+ARG VERBOSE=false
 RUN configure.sh
 ```
 
@@ -170,6 +182,7 @@ USER root
 RUN apt-get update && apt-get install -y curl
 USER 1001
 ARG FEATURE_REPO_URL=http://wlprepos:8080/19.0.0.x/repo.zip
+ARG VERBOSE=false
 RUN configure.sh
 ```
 

--- a/ga/19.0.0.12/kernel/helpers/build/configure.sh
+++ b/ga/19.0.0.12/kernel/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/ga/19.0.0.9/kernel/helpers/build/configure.sh
+++ b/ga/19.0.0.9/kernel/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
 set -Eeox pipefail
 
 ##Define variables for XML snippets source and target paths

--- a/test/test-stock-quote/Dockerfile
+++ b/test/test-stock-quote/Dockerfile
@@ -13,9 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
+ARG IMAGE=ibmcom/websphere-liberty:full-java8-openj9-ubi
+FROM ${IMAGE}
 
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 stock-quote-1.0-SNAPSHOT.war /config/apps/StockQuote.war
+
+ARG VERBOSE=false
 
 RUN configure.sh

--- a/test/test-stock-quote/Dockerfile
+++ b/test/test-stock-quote/Dockerfile
@@ -13,8 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG IMAGE=ibmcom/websphere-liberty:full-java8-openj9-ubi
-FROM ${IMAGE}
+FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
 
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 stock-quote-1.0-SNAPSHOT.war /config/apps/StockQuote.war

--- a/test/test-stock-trader/Dockerfile
+++ b/test/test-stock-trader/Dockerfile
@@ -18,4 +18,6 @@ FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
 COPY --chown=1001:0 config /config/
 COPY --chown=1001:0 trader-1.0-SNAPSHOT.war /config/apps/TraderUI.war
 
+ARG VERBOSE=false
+
 RUN configure.sh


### PR DESCRIPTION
* Redirects the standard output from `configure.sh` based on how the user specifies the build argument `VERBOSE`
* If the user sets `VERBOSE` to `true` all output from `configure.sh` is outputted.
* Changes the directions for the `Dockerfile` in the `README` to include the default `ARG VERBOSE`
