### PR TITLE
Add OpenJ9 multi-layer SCCs to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Docker Hub images
 
 There are two different supported WebSphere Liberty Docker image sets available on Docker Hub:
-1.  Our recommended set [here](https://hub.docker.com/r/ibmcom/websphere-liberty).  These are images using Red Hat's [Universal Base Image](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as the Operating System and are re-built daily.  
+1.  Our recommended set [here](https://hub.docker.com/r/ibmcom/websphere-liberty).  These are images using Red Hat's [Universal Base Image](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as the Operating System and are re-built daily.
 2.  Other sets can be found [here](https://hub.docker.com/_/websphere-liberty).  These are re-built automatically anytime something changes in the layers below.  There are tags with different combinations of Java and Operating System versions.
 
 
@@ -66,15 +66,26 @@ This section describes the optional enterprise functionality that can be enabled
   *  Decription: Enable OpenIdConnect Client function by adding the `openidConnectClient-1.0` feature.
   *  XML Snippet Location: [oidc.xml](ga/latest/kernel/helpers/build/configuration_snippets/oidc.xml)
 * `OIDC_CONFIG`
-  *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.  
+  *  Decription: Enable OpenIdConnect Client configuration to be read from environment variables.
   *  XML Snippet Location: [oidc-config.xml](ga/latest/kernel/helpers/build/configuration_snippets/oidc-config.xml)
-  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.  
+  *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.
 * `HZ_SESSION_CACHE`
   *  Decription: Enable the persistence of HTTP sessions using JCache by adding the `sessionCache-1.0` feature.
   *  XML Snippet Location: [hazelcast-sessioncache.xml](ga/latest/kernel/helpers/build/configuration_snippets/hazelcast-sessioncache.xml)
 *  `VERBOSE`
   * Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Otherwise, default setting is `false` and `configure.sh` is silenced.
 
+## OpenJ9 Shared Class Cache (SCC)
+
+OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.
+
+WebSphere Liberty Docker images contain an SCC and (by default) add your application's specific data to the SCC at image build time when your Dockerfile invokes `RUN configure.sh`.
+
+This feature can be controlled via the following variables:
+
+* `OPENJ9_SCC` (environment variable)
+  *  Decription: If `"true"`, cache application-specific in an SCC and include it in the image. A new SCC will be created if needed, otherwise data will be added to the existing SCC.
+  *  Default: `"true"`.
 
 ### Logging
 

--- a/ga/20.0.0.3/full/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.3/full/Dockerfile.ubi.adoptopenjdk11
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM ibmcom/websphere-liberty:20.0.0.3-kernel-java11-openj9-ubi
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/20.0.0.3/full/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.3/full/Dockerfile.ubi.adoptopenjdk8
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM ibmcom/websphere-liberty:20.0.0.3-kernel-java8-openj9-ubi
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/20.0.0.3/full/Dockerfile.ubi.ibmjava8
+++ b/ga/20.0.0.3/full/Dockerfile.ubi.ibmjava8
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM ibmcom/websphere-liberty:20.0.0.3-kernel-java8-ibmjava-ubi
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/20.0.0.3/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/20.0.0.3/full/Dockerfile.ubuntu.ibmjava8
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM websphere-liberty:20.0.0.3-kernel-java8-ibmjava
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -14,6 +14,9 @@
 
 FROM adoptopenjdk/openjdk11-openj9:ubi
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -56,7 +59,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -96,6 +100,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -14,6 +14,9 @@
 
 FROM adoptopenjdk/openjdk8-openj9:ubi
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -56,7 +59,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -96,6 +100,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/20.0.0.3/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubi.ibmjava8
@@ -14,6 +14,9 @@
 
 FROM ibmjava:8-ubi
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -55,7 +58,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -95,6 +99,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/20.0.0.3/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubuntu.ibmjava8
@@ -14,6 +14,9 @@
 
 FROM ibmjava:8-jre
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -24,7 +27,7 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_03
 
-ARG LIBERTY_URL 
+ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
 
 RUN apt-get update \
@@ -52,7 +55,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output 
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -92,6 +96,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/20.0.0.3/kernel/helpers/build/configure.sh
+++ b/ga/20.0.0.3/kernel/helpers/build/configure.sh
@@ -104,9 +104,12 @@ fi
 # Fixes recommended by IBM, such as to resolve security vulnerabilities, are also included in /opt/ibm/fixes
 # Note: This step should be done once needed features are enabled and installed using installUtility.
 find /opt/ibm/fixes -type f -name "*.jar"  -print0 | sort -z | xargs -0 -n 1 -r -I {} java -jar {} --installLocation $WLP_INSTALL_DIR
-#Make sure that group write permissions are set correctly after installing new features 
+#Make sure that group write permissions are set correctly after installing new features
 find /opt/ibm/wlp -perm -g=w -print0 | xargs -0 -r chmod -R g+rw
-# Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea && chmod -R g+rwx /opt/ibm/wlp/output/*
+# Create a new SCC layer
+if [ "$OPENJ9_SCC" == "true" ]
+then
+  populate_scc.sh
+fi
 #Make folder executable for a group
 find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx

--- a/ga/20.0.0.3/kernel/helpers/build/populate_scc.sh
+++ b/ga/20.0.0.3/kernel/helpers/build/populate_scc.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
+set -Eeox pipefail
+
+SCC_SIZE="80m"  # Default size of the SCC layer.
+ITERATIONS=2    # Number of iterations to run to populate it.
+TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
+
+while getopts ":i:s:tdh" OPT
+do
+  case "$OPT" in
+    i)
+      ITERATIONS="$OPTARG"
+      ;;
+    s)
+      [ "${OPTARG: -1}" == "m" ] || ( echo "Missing m suffix." && exit 1 )
+      SCC_SIZE="$OPTARG"
+      ;;
+    t)
+      TRIM_SCC=yes
+      ;;
+    d)
+      TRIM_SCC=no
+      ;;
+    h)
+      echo \
+"Usage: $0 [-i iterations] [-s size] [-t] [-d]
+  -i <iterations> Number of iterations to run to populate the SCC. (Default: $ITERATIONS)
+  -s <size>       Size of the SCC in megabytes (m suffix required). (Default: $SCC_SIZE)
+  -t              Trim the SCC to eliminate most of the free space, if any.
+  -d              Don't trim the SCC.
+
+  Trimming enabled=$TRIM_SCC"
+      exit 1
+      ;;
+    \?)
+      echo "Unrecognized option: $OPTARG" 1>&2
+      exit 1
+      ;;
+    :)
+      echo "Missing argument for option: $OPTARG" 1>&2
+      exit 1
+      ;;
+  esac
+done
+
+# Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+unset IBM_JAVA_OPTIONS
+
+# Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+
+if [ $TRIM_SCC == yes ]
+then
+  echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
+  # Populate the newly created class cache layer.
+  export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+  /opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop
+  # Find out how full it is.
+  unset IBM_JAVA_OPTIONS
+  FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+  echo "SCC layer is $FULL% full. Destroying layer."
+  # Destroy the layer once we know roughly how much space we need.
+  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
+  # Remove the m suffix.
+  SCC_SIZE="${SCC_SIZE:0:-1}"
+  # Calculate the new size based on how full the layer was (rounded to nearest m).
+  SCC_SIZE=`awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0 + 0.5)}"`
+  # Make sure size is >0.
+  [ $SCC_SIZE -eq 0 ] && SCC_SIZE=1
+  # Add the m suffix back.
+  SCC_SIZE="${SCC_SIZE}m"
+  echo "Re-creating layer with size $SCC_SIZE."
+  # Recreate the layer with the new size.
+  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+fi
+
+# Populate the newly created class cache layer.
+export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster.
+for ((i=0; i<$ITERATIONS; i++))
+do
+  /opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop
+done
+
+rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
+
+unset IBM_JAVA_OPTIONS
+# Tell the user how full the final layer is.
+FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+echo "SCC layer is $FULL% full."

--- a/ga/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM ibmcom/websphere-liberty:kernel-java11-openj9-ubi
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM ibmcom/websphere-liberty:kernel-java8-openj9-ubi
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/full/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubi.ibmjava8
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM ibmcom/websphere-liberty:kernel-java8-ibmjava-ubi
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubuntu.ibmjava8
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM websphere-liberty:kernel
-
+ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
 RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
@@ -24,3 +24,9 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && chmod -R g+rwx /opt/ibm/wlp/output/*
 
 COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -14,6 +14,9 @@
 
 FROM adoptopenjdk/openjdk11-openj9:ubi
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -56,7 +59,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -96,6 +100,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -14,6 +14,9 @@
 
 FROM adoptopenjdk/openjdk8-openj9:ubi
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -56,7 +59,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -96,6 +100,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -14,6 +14,9 @@
 
 FROM ibmjava:8-ubi
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -55,7 +58,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -95,6 +99,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
@@ -14,6 +14,9 @@
 
 FROM ibmjava:8-jre
 
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+
 LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
@@ -24,7 +27,7 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_03
 
-ARG LIBERTY_URL 
+ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
 
 RUN apt-get update \
@@ -52,7 +55,8 @@ LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \
-    WLP_OUTPUT_DIR=/opt/ibm/wlp/output 
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
 
 # Configure WebSphere Liberty
 RUN /opt/ibm/wlp/bin/server create \
@@ -92,6 +96,12 @@ RUN mkdir /logs \
     && chmod -R g+rw /etc/wlp \
     && chown -R 1001:0 /home/default \
     && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -104,9 +104,12 @@ fi
 # Fixes recommended by IBM, such as to resolve security vulnerabilities, are also included in /opt/ibm/fixes
 # Note: This step should be done once needed features are enabled and installed using installUtility.
 find /opt/ibm/fixes -type f -name "*.jar"  -print0 | sort -z | xargs -0 -n 1 -r -I {} java -jar {} --installLocation $WLP_INSTALL_DIR
-#Make sure that group write permissions are set correctly after installing new features 
+#Make sure that group write permissions are set correctly after installing new features
 find /opt/ibm/wlp -perm -g=w -print0 | xargs -0 -r chmod -R g+rw
-# Server start/stop to populate the /output/workarea and make subsequent server starts faster
-/opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop && rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache /output/workarea && chmod -R g+rwx /opt/ibm/wlp/output/*
+# Create a new SCC layer
+if [ "$OPENJ9_SCC" == "true" ]
+then
+  populate_scc.sh
+fi
 #Make folder executable for a group
 find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx

--- a/ga/latest/kernel/helpers/build/populate_scc.sh
+++ b/ga/latest/kernel/helpers/build/populate_scc.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+if [ "$VERBOSE" != "true" ]; then
+  exec &>/dev/null
+fi
+
+set -Eeox pipefail
+
+SCC_SIZE="80m"  # Default size of the SCC layer.
+ITERATIONS=2    # Number of iterations to run to populate it.
+TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
+
+while getopts ":i:s:tdh" OPT
+do
+  case "$OPT" in
+    i)
+      ITERATIONS="$OPTARG"
+      ;;
+    s)
+      [ "${OPTARG: -1}" == "m" ] || ( echo "Missing m suffix." && exit 1 )
+      SCC_SIZE="$OPTARG"
+      ;;
+    t)
+      TRIM_SCC=yes
+      ;;
+    d)
+      TRIM_SCC=no
+      ;;
+    h)
+      echo \
+"Usage: $0 [-i iterations] [-s size] [-t] [-d]
+  -i <iterations> Number of iterations to run to populate the SCC. (Default: $ITERATIONS)
+  -s <size>       Size of the SCC in megabytes (m suffix required). (Default: $SCC_SIZE)
+  -t              Trim the SCC to eliminate most of the free space, if any.
+  -d              Don't trim the SCC.
+
+  Trimming enabled=$TRIM_SCC"
+      exit 1
+      ;;
+    \?)
+      echo "Unrecognized option: $OPTARG" 1>&2
+      exit 1
+      ;;
+    :)
+      echo "Missing argument for option: $OPTARG" 1>&2
+      exit 1
+      ;;
+  esac
+done
+
+# Make sure the following Java commands don't disturb our class cache until we're ready to populate it
+# by unsetting IBM_JAVA_OPTIONS if it is currently defined.
+unset IBM_JAVA_OPTIONS
+
+# Explicity create a class cache layer for this image layer here rather than allowing
+# `server start` to do it, which will lead to problems because multiple JVMs will be started.
+java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+
+if [ $TRIM_SCC == yes ]
+then
+  echo "Calculating SCC layer upper bound, starting with initial size $SCC_SIZE."
+  # Populate the newly created class cache layer.
+  export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+  /opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop
+  # Find out how full it is.
+  unset IBM_JAVA_OPTIONS
+  FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+  echo "SCC layer is $FULL% full. Destroying layer."
+  # Destroy the layer once we know roughly how much space we need.
+  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,destroy || true
+  # Remove the m suffix.
+  SCC_SIZE="${SCC_SIZE:0:-1}"
+  # Calculate the new size based on how full the layer was (rounded to nearest m).
+  SCC_SIZE=`awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0 + 0.5)}"`
+  # Make sure size is >0.
+  [ $SCC_SIZE -eq 0 ] && SCC_SIZE=1
+  # Add the m suffix back.
+  SCC_SIZE="${SCC_SIZE}m"
+  echo "Re-creating layer with size $SCC_SIZE."
+  # Recreate the layer with the new size.
+  java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,createLayer -Xscmx$SCC_SIZE -version
+fi
+
+# Populate the newly created class cache layer.
+export IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+
+# Server start/stop to populate the /output/workarea and make subsequent server starts faster.
+for ((i=0; i<$ITERATIONS; i++))
+do
+  /opt/ibm/wlp/bin/server start && /opt/ibm/wlp/bin/server stop
+done
+
+rm -rf /output/messaging /logs/* $WLP_OUTPUT_DIR/.classCache && chmod -R g+rwx /opt/ibm/wlp/output/*
+
+unset IBM_JAVA_OPTIONS
+# Tell the user how full the final layer is.
+FULL=`( java -Xshareclasses:name=liberty,cacheDir=/output/.classCache/,printTopLayerStats || true ) 2>&1 | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'`
+echo "SCC layer is $FULL% full."


### PR DESCRIPTION
This patch
- introduces the populate_scc.sh script to manage creating and populating
OpenJ9 SCC cache layers,
- adds multi-layer SCCs to the kernel and full OpenJ9 and IBM JDK images,
- and allows for user images that call configure.sh to add their data to
the existing caches.