### PR TITLE
Update image labels for base image changes

### DIFF
--- a/ga/19.0.0.12/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/19.0.0.12/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -23,8 +23,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="19.0.0.12" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with AdoptOpenJDK with OpenJ9 and Red Hat UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_12

--- a/ga/19.0.0.12/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/19.0.0.12/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -23,8 +23,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="19.0.0.12" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_12

--- a/ga/19.0.0.12/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/19.0.0.12/kernel/Dockerfile.ubi.ibmjava8
@@ -23,8 +23,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="19.0.0.12" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with IBM's Java and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with IBM's Java and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_12

--- a/ga/19.0.0.12/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/19.0.0.12/kernel/Dockerfile.ubuntu.ibmjava8
@@ -19,7 +19,12 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
       org.opencontainers.image.version="19.0.0.12" \
-      org.opencontainers.image.revision="cl191220191120-0300"
+      org.opencontainers.image.revision="cl191220191120-0300" \
+      vendor="IBM" \
+      name="IBM WebSphere Liberty" \
+      version="19.0.0.12" \
+      summary="Image for WebSphere Liberty with IBM's Java and Ubuntu" \
+      description="This image contains the WebSphere Liberty runtime with IBM's Java and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 19.0.0_12

--- a/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -26,8 +26,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="20.0.0.3" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_03

--- a/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -26,8 +26,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="20.0.0.3" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_03

--- a/ga/20.0.0.3/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubi.ibmjava8
@@ -26,8 +26,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="20.0.0.3" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with IBM's Java and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with IBM's Java and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_03

--- a/ga/20.0.0.3/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubuntu.ibmjava8
@@ -25,7 +25,7 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.revision="cl200320200305-1433" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
-      version="19.0.0.12" \
+      version="20.0.0.3" \
       summary="Image for WebSphere Liberty with IBM's Java and Ubuntu" \
       description="This image contains the WebSphere Liberty runtime with IBM's Java and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 

--- a/ga/20.0.0.3/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/20.0.0.3/kernel/Dockerfile.ubuntu.ibmjava8
@@ -22,7 +22,12 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
       org.opencontainers.image.version="20.0.0.3" \
-      org.opencontainers.image.revision="cl200320200305-1433"
+      org.opencontainers.image.revision="cl200320200305-1433" \
+      vendor="IBM" \
+      name="IBM WebSphere Liberty" \
+      version="19.0.0.12" \
+      summary="Image for WebSphere Liberty with IBM's Java and Ubuntu" \
+      description="This image contains the WebSphere Liberty runtime with IBM's Java and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_03

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -26,8 +26,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="20.0.0.4" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_04

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -26,8 +26,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="20.0.0.4" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with AdoptOpenJDK with OpenJ9 and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with AdopOpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_04

--- a/ga/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -26,8 +26,8 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
       version="20.0.0.4" \
-      summary="Image for WebSphere Liberty with IBM's SFJ and UBI minimal" \
-      description="This image contains the WebSphere Liberty runtime with IBM's SFJ and Red Hat UBI minimal as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
+      summary="Image for WebSphere Liberty with IBM's Java and Red Hat's UBI 8" \
+      description="This image contains the WebSphere Liberty runtime with IBM's Java and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_04

--- a/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
@@ -22,7 +22,12 @@ LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
       org.opencontainers.image.version="20.0.0.4" \
-      org.opencontainers.image.revision="cl200420200401-1714"
+      org.opencontainers.image.revision="cl200420200401-1714" \
+      vendor="IBM" \
+      name="IBM WebSphere Liberty" \
+      version="20.0.0.4" \
+      summary="Image for WebSphere Liberty with IBM's Java and Ubuntu" \
+      description="This image contains the WebSphere Liberty runtime with IBM's Java and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
 ENV LIBERTY_VERSION 20.0.0_04


### PR DESCRIPTION
* Update existing labels to match the new base OS/Java images

* Add missing labels to Ubuntu based images for version and descriptions

Fixes #327 