### PR TITLE
Update Dockerfile.ubuntu.ibmjava8

### DIFF
--- a/ga/20.0.0.6/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/20.0.0.6/full/Dockerfile.ubuntu.ibmjava8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM websphere-liberty:20.0.0.6-kernel-java8-openj9
+FROM websphere-liberty:20.0.0.6-kernel-java8-ibmjava
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 


### PR DESCRIPTION
WebSphere Liberty uses IBM Java for its Ubuntu image.