### PR TITLE
Prefer Liberty SCC to OpenJ9 SCC

### DIFF
--- a/ga/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -109,7 +109,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.6/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -109,7 +109,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/20.0.0.6/kernel/helpers/build/populate_scc.sh
+++ b/ga/20.0.0.6/kernel/helpers/build/populate_scc.sh
@@ -30,10 +30,11 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer"
-DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
-PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export IBM_JAVA_OPTIONS="${OPENJ9_JAVA_OPTIONS}"
+CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer"
+DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"
 
 while getopts ":i:s:tdh" OPT
 do

--- a/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -109,7 +109,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -109,7 +109,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/20.0.0.9/kernel/helpers/build/populate_scc.sh
+++ b/ga/20.0.0.9/kernel/helpers/build/populate_scc.sh
@@ -30,10 +30,11 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer"
-DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
-PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export IBM_JAVA_OPTIONS="${OPENJ9_JAVA_OPTIONS}"
+CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer"
+DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"
 
 while getopts ":i:s:tdh" OPT
 do

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -109,7 +109,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -109,7 +109,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
 ENV RANDFILE=/tmp/.rnd \
-    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
 
 USER 1001
 

--- a/ga/latest/kernel/helpers/build/populate_scc.sh
+++ b/ga/latest/kernel/helpers/build/populate_scc.sh
@@ -30,10 +30,11 @@ TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export IBM_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
-CREATE_LAYER="$IBM_JAVA_OPTIONS,createLayer"
-DESTROY_LAYER="$IBM_JAVA_OPTIONS,destroy"
-PRINT_LAYER_STATS="$IBM_JAVA_OPTIONS,printTopLayerStats"
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -Xshareclasses:name=liberty,cacheDir=/output/.classCache/"
+export IBM_JAVA_OPTIONS="${OPENJ9_JAVA_OPTIONS}"
+CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer"
+DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"
+PRINT_LAYER_STATS="$OPENJ9_JAVA_OPTIONS,printTopLayerStats"
 
 while getopts ":i:s:tdh" OPT
 do


### PR DESCRIPTION
Note: This fix corresponds to a similar one in Open Liberty: https://github.com/OpenLiberty/ci.docker/pull/204.

On some systems trying to use the OpenJ9 SCC leads to
permission denied errors, despite file permissions being
observably correct.

For the time being we'll ignore the OpenJ9 SCC and
continue to build our own SCC layers. In order to do this
we switch to setting/using the OPENJ9_JAVA_OPTIONS
env var in order to override the OpenJ9 image and move
away from IBM_JAVA_OPTIONS, which is deprecated anyway.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>