### PR TITLE
Fix file name issue in security check for license files

### DIFF
--- a/ga/20.0.0.11/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.11/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -49,7 +49,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \

--- a/ga/20.0.0.11/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.11/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -49,7 +49,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \

--- a/ga/20.0.0.11/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/20.0.0.11/kernel/Dockerfile.ubi.ibmjava8
@@ -48,7 +48,7 @@ RUN yum -y install unzip wget openssl \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \

--- a/ga/20.0.0.11/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/20.0.0.11/kernel/Dockerfile.ubuntu.ibmjava8
@@ -52,7 +52,7 @@ RUN apt-get update \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && apt-get purge --auto-remove -y unzip \
     && apt-get purge --auto-remove -y wget \

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -49,7 +49,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -49,7 +49,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \

--- a/ga/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -48,7 +48,7 @@ RUN yum -y install unzip wget openssl \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && chmod -R g+x /usr/bin \
     && unzip -q /tmp/wlp.zip -d /opt/ibm \

--- a/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
@@ -52,7 +52,7 @@ RUN apt-get update \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
     && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
-    && echo "$NON_IBM_SHA /licenses/non_ibm_licenses.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
     && apt-get purge --auto-remove -y unzip \
     && apt-get purge --auto-remove -y wget \


### PR DESCRIPTION
non_ibm_license.html was accidentally pluralized.