### PR TITLE
Build on OpenJ9 system SCC when possible

### DIFF
--- a/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -108,8 +108,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/20.0.0.9/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -108,8 +108,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk11
@@ -47,7 +47,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
     && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
-    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
+    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
     && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
@@ -117,8 +117,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 

--- a/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.adoptopenjdk8
@@ -47,7 +47,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
     && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
-    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
+    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \
     && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
     && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
     && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
@@ -117,8 +117,7 @@ RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && chmod -R g+rwx /opt/ibm/wlp/output
 
 #These settings are needed so that we can run as a different user than 1001 after server warmup
-ENV RANDFILE=/tmp/.rnd \
-    OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/"
+ENV RANDFILE=/tmp/.rnd
 
 USER 1001
 


### PR DESCRIPTION
If /opt/java/.scc exists and is readable, assume that an OpenJ9 system
SCC named "openj9_system_scc" exists and build the current image's
SCC layer on top of it. If it doesn't exist or is not readable,
continue to build on the Liberty SCC named "liberty" in
/output/.classCache.

The above will result in images based on IBM JDK continuing to build
a Liberty SCC (as the IBM JDK image does not ship with an SCC) and
OpenJ9 based images building on the OpenJ9 system SCC, except when
directory permissions prevent non-root access.

This last condition is to allow for gracefully handling older OpenJ9
images that did not allow for non-root SCC access.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>