### PR TITLE
Add Ubuntu + OpenJ9 11 images

### DIFF
--- a/ga/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/ga/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -1,0 +1,32 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM websphere-liberty:kernel-java11-openj9
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && chmod -R g+rwx /opt/ibm/wlp/output/*
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/kernel/Dockerfile.ubuntu.adoptopenjdk11
+++ b/ga/latest/kernel/Dockerfile.ubuntu.adoptopenjdk11
@@ -1,0 +1,125 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM adoptopenjdk:11-jre-openj9
+
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+ARG EN_SHA=94d859d22ee00758a00b75f9ef52772ecf1c52b4055a9f997f4f99423b17c033
+ARG NON_IBM_SHA=e425adf53bb63f1c53060c1b05f6fb553af433f64460daee51f965cff230e285
+ARG NOTICES_SHA=aae32415dc8f4195b2b8393990fee937bd6d5836622ecce1c12c6d77cdb83ad4
+
+LABEL org.opencontainers.image.authors="Arthur De Magalhaes, Chris Potter, Christy Jesuraj" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="20.0.0.11" \
+      org.opencontainers.image.revision="cl201120201014-1215" \
+      org.opencontainers.image.description="This image contains the WebSphere Liberty runtime with AdoptOpenJDK with OpenJ9 and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image" \
+      org.opencontainers.image.title="IBM WebSphere Liberty"
+
+# Install WebSphere Liberty
+ENV LIBERTY_VERSION 20.0.0_11
+
+ARG LIBERTY_URL
+ARG DOWNLOAD_OPTIONS=""
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip wget openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /licenses/ \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
+    && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && unzip -q /tmp/wlp.zip -d /opt/ibm \
+    && rm /tmp/wlp.zip \
+    && chown -R 1001:0 /opt/ibm/wlp \
+    && chmod -R g+rw /opt/ibm/wlp \
+    && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
+    && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
+    && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
+    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \    
+    && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
+    && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
+    && apt-get purge --auto-remove -y unzip \
+    && apt-get purge --auto-remove -y wget \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/ibm/wlp/bin:/opt/ibm/helpers/build:$PATH
+
+# Add labels for consumption by IBM Product Insights
+LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
+      "ProductName"="WebSphere Application Server Liberty" \
+      "ProductVersion"="20.0.0.11" \
+      "BuildLabel"="cl201120201014-1215"
+
+# Set Path Shortcuts
+ENV LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure WebSphere Liberty
+RUN /opt/ibm/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+COPY helpers/ /opt/ibm/helpers/
+COPY fixes/ /opt/ibm/fixes/
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir /etc/wlp \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+    && mkdir -p /home/default \
+    && mkdir /output \
+    && chmod -t /output \
+    && rm -rf /output \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
+    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /opt/ibm/helpers \
+    && chmod -R g+rwx /opt/ibm/helpers \
+    && chown -R 1001:0 /opt/ibm/fixes \
+    && chmod -R g+rwx /opt/ibm/fixes \
+    && chown -R 1001:0 /opt/ibm/wlp/usr \
+    && chmod -R g+rw /opt/ibm/wlp/usr \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rw /opt/ibm/wlp/output \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ibm/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
@@ -46,7 +46,6 @@ RUN apt-get update \
     && rm /tmp/wlp.zip \
     && chown -R 1001:0 /opt/ibm/wlp \
     && chmod -R g+rw /opt/ibm/wlp \
-    && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
     && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
     && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
     && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \


### PR DESCRIPTION
- Add OpenJ9 Java 11 support on Ubuntu
- Fixed minor bug in ga/latest/kernel/Dockerfile.ubuntu.ibmjava8 where wlp.zip is downloaded twice 