### PR TITLE
Reduce SCC build time for app images

### DIFF
--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -134,7 +134,7 @@ function main() {
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]
   then
-    populate_scc.sh
+    populate_scc.sh -i 1
   fi
   #Make folder executable for a group
   find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx


### PR DESCRIPTION
This change equivalent to https://github.com/OpenLiberty/ci.docker/pull/228. Build and runtime performance deltas for this change are in line with what was observed for Open Liberty running the same benchmarks (Acme Air and DT7).

Currently every image in the stack runs the server 4 times to build
its SCC layer. The final 2 iterations are optional but allow for the
refinement of profiling information. This patch reduces the number
of optional iterations for app images from 2 to 1 to reduce build
times on the basis that it does not sacrifice much, if any,
start-up performance. It does not affect the number of iterations
used for server SCC layers.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>