### PR TITLE
Changes to reduce end container size.

### DIFF
--- a/ga/latest/full/Dockerfile.ubi.adoptopenjdk11
+++ b/ga/latest/full/Dockerfile.ubi.adoptopenjdk11
@@ -21,12 +21,12 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && chmod -R g+rwx /opt/ibm/wlp/output/*
+  && chmod -R g+rwx /opt/ibm/wlp/output/* \
+  && find /opt/ibm/wlp/bin /opt/ibm/wlp/lib -type d -perm -g=w -print0 | xargs -0 -I{} find {} -type f ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
 
 COPY --chown=1001:0 server.xml /config/
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
-    && chown -R 1001:0 /opt/ibm/wlp/output \
     && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/full/Dockerfile.ubi.adoptopenjdk8
+++ b/ga/latest/full/Dockerfile.ubi.adoptopenjdk8
@@ -21,12 +21,12 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && chmod -R g+rwx /opt/ibm/wlp/output/*
+  && chmod -R g+rwx /opt/ibm/wlp/output/* \
+  && find /opt/ibm/wlp/bin /opt/ibm/wlp/lib -type d -perm -g=w -print0 | xargs -0 -I{} find {} -type f ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
 
 COPY --chown=1001:0 server.xml /config/
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
-    && chown -R 1001:0 /opt/ibm/wlp/output \
     && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/full/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubi.ibmjava8
@@ -21,7 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx
+  && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx \
+  && find /opt/ibm/wlp/bin /opt/ibm/wlp/lib -type d -perm -g=w -print0 | xargs -0 -I{} find {} -type f ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/latest/full/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubi.ibmjava8
@@ -21,12 +21,11 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && chmod -R g+rwx /opt/ibm/wlp/output/*
+  && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx
 
 COPY --chown=1001:0 server.xml /config/
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
-    && chown -R 1001:0 /opt/ibm/wlp/output \
-    && chmod -R g+rwx /opt/ibm/wlp/output
+    && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx

--- a/ga/latest/full/Dockerfile.ubuntu.adoptopenjdk11
+++ b/ga/latest/full/Dockerfile.ubuntu.adoptopenjdk11
@@ -21,12 +21,12 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && chmod -R g+rwx /opt/ibm/wlp/output/*
+  && chmod -R g+rwx /opt/ibm/wlp/output/* \
+  && find /opt/ibm/wlp/bin /opt/ibm/wlp/lib -type d -perm -g=w -print0 | xargs -0 -I{} find {} -type f ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
 
 COPY --chown=1001:0 server.xml /config/
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
-    && chown -R 1001:0 /opt/ibm/wlp/output \
     && chmod -R g+rwx /opt/ibm/wlp/output

--- a/ga/latest/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubuntu.ibmjava8
@@ -21,7 +21,8 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx
+  && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx \
+  && find /opt/ibm/wlp/bin /opt/ibm/wlp/lib -type d -perm -g=w -print0 | xargs -0 -I{} find {} -type f ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/latest/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubuntu.ibmjava8
@@ -21,12 +21,11 @@ RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
   && installUtility install --acceptLicense baseBundle \
   && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
   && rm -rf /output/workarea /output/logs \
-  && chmod -R g+rwx /opt/ibm/wlp/output/*
+  && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx
 
 COPY --chown=1001:0 server.xml /config/
 
 # Create a new SCC layer
 RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
-    && chown -R 1001:0 /opt/ibm/wlp/output \
-    && chmod -R g+rwx /opt/ibm/wlp/output
+    && find /opt/ibm/wlp/output/ ! -path "*.classCache*" -print0 | xargs -0 -r chmod g+rwx

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -130,7 +130,7 @@ function main() {
   # Note: This step should be done once needed features are enabled and installed using installUtility.
   find /opt/ibm/fixes -type f -name "*.jar"  -print0 | sort -z | xargs -0 -n 1 -r -I {} java -jar {} --installLocation $WLP_INSTALL_DIR
   #Make sure that group write permissions are set correctly after installing new features
-  find /opt/ibm/wlp -perm -g=w ! -perm -g=r -print0 | xargs -0 -r chmod -R g+rw
+  find /opt/ibm/wlp/bin /opt/ibm/wlp/lib -type d -perm -g=w -print0 | xargs -0 -I{} find {} -type f ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
 
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -130,14 +130,13 @@ function main() {
   # Note: This step should be done once needed features are enabled and installed using installUtility.
   find /opt/ibm/fixes -type f -name "*.jar"  -print0 | sort -z | xargs -0 -n 1 -r -I {} java -jar {} --installLocation $WLP_INSTALL_DIR
   #Make sure that group write permissions are set correctly after installing new features
-  find /opt/ibm/wlp -perm -g=w -print0 | xargs -0 -r chmod -R g+rw
+  find /opt/ibm/wlp -perm -g=w ! -perm -g=r -print0 | xargs -0 -r chmod -R g+rw
+
   # Create a new SCC layer
   if [ "$OPENJ9_SCC" == "true" ]
   then
     populate_scc.sh -i 1
   fi
-  #Make folder executable for a group
-  find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx
 }
 
 ## parse provider list to generate files into configDropins


### PR DESCRIPTION
Attempt to fix https://github.com/WASdev/ci.docker/issues/385.

With these changes a container made the websphere-liberty:full image goes from 1.01GB in size down to 639MB.

1. Changes to the **full** Dockerfiles
    - Only change permissions of files that need it after running installUtility. This is so we don't do it in another layer later, which avoids the duplication of layers. 
    - Don't change the permissions of the .classCache dir if using IBM JDK as it is already fine. (openj9 has the classCache in a different location so doesn't apply there)
    - I don't think we need to set the user 1001 as everything is running as 1001 at this point.

2. Changed populate_scc.sh to be like open-liberty and make the scc layer have group rw perms when created.

3. Changes to configure.sh 
   - Only change the perms on files that need it after running installUtility.
   - Took out the following line, which I am not sure about. I not sure what it is there for, it is not in open-liberty.
   ```find /opt/ibm/wlp -type d -perm -g=x -print0 | xargs -0 -r chmod -R g+rwx```

