### PR TITLE
Document images in ICR and use containers instead of Docker

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,7 @@ Since HTTPS is usually required, these settings can simplify setting it up:
 Each Single Sign-On provider needs some additional configuration to be functional -  a client Id, client secret and sometimes more. These variables can be supplied in several ways:
   * At build time, they can be variables in a server.xml file (`<variable name="foo" value="bar" />`).
   * At build time, they can be ENV variables in the Dockerfile, this is less secure (`ENV name=value`).
-  * They can be passed as environment variables to the Docker container when it is deployed. 
+  * They can be passed as environment variables to the container when it is deployed. 
   * They can be supplied in a deployment YAML file or by the [Liberty operator](https://github.com/OpenLiberty/open-liberty-operator/blob/master/doc/user-guide.adoc#single-sign-on-sso), which will pass them to the container at deploy time.
 
 Client ID and Client Secret are obtained from the provider.  RedirectToRPHostAndPort (`SEC_SSO_REDIRECTTORPHOSTANDPORT`) is the protocol, host, and port that the provider should send the browser back to after authentication, for example `https://myApp-myNamespace-myClusterHostname.mycompany.com`  (In some container environments, the pod cannot figure this out and it will need to be specified.) Other variables may be needed in some situations and are documented in detail in the [Open Liberty Documentation](https://openliberty.io/docs/ref/feature/#socialLogin-1.0.html) under each type of provider. The `oidc` and `oauth2` configurations are general purpose configurations for use with any provider that uses the OpenID Connect 1.0 or OAuth 2.0 specifications.

--- a/beta/README.md
+++ b/beta/README.md
@@ -1,4 +1,4 @@
-# WebSphere Application Server Liberty Beta image for Docker
+# WebSphere Application Server Liberty Beta Image
 
 **Important Notice: WebSphere Liberty beta is no longer available. The `beta` tag is now deprecated.** 
 
@@ -6,4 +6,4 @@ The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-l
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, change to the `beta/` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, change to the `beta/` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.

--- a/docs/icr-images.md
+++ b/docs/icr-images.md
@@ -1,0 +1,60 @@
+
+# IBM Container Registry (ICR)
+
+WebSphere Liberty container images are available from IBM Container Registry (ICR) at `icr.io/appcafe/websphere-liberty`. Our recommendation is to use ICR instead of Docker Hub, since ICR doesn't impose rate limits on image pulls. Images can be pulled from ICR without authentication. Only images with Universal Base Image (UBI) as the Operating System are available in ICR at the moment.
+
+The images for the latest fix pack and the last two quarterly releases are available at all times and are refreshed regularly.
+
+Available image tags are listed below. The tags follow this naming convention: `<fixpack_version_optional>-<liberty_image_flavour>-<java_version>-<java_type>-ubi`
+
+Append a tag to `icr.io/appcafe/websphere-liberty` to pull a specific image. For example, `icr.io/appcafe/websphere-liberty:21.0.0.11-kernel-java8-openj9-ubi`
+
+Available images can also be listed using [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cli-getting-started). Log in with your IBMid prior to running this command: `ibmcloud cr images --restrict appcafe/websphere-liberty`
+
+## Latest fixpack
+
+```
+kernel-java8-openj9-ubi
+kernel-java8-ibmjava-ubi
+kernel-java11-openj9-ubi
+
+full-java8-openj9-ubi
+full-java8-ibmjava-ubi
+full-java11-openj9-ubi
+```
+
+## 21.0.0.11
+
+```
+21.0.0.11-kernel-java8-openj9-ubi
+21.0.0.11-kernel-java8-ibmjava-ubi
+21.0.0.11-kernel-java11-openj9-ubi
+
+21.0.0.11-full-java8-openj9-ubi
+21.0.0.11-full-java8-ibmjava-ubi
+21.0.0.11-full-java11-openj9-ubi
+```
+
+## 21.0.0.9
+
+```
+21.0.0.9-kernel-java8-openj9-ubi
+21.0.0.9-kernel-java8-ibmjava-ubi
+21.0.0.9-kernel-java11-openj9-ubi
+
+21.0.0.9-full-java8-openj9-ubi
+21.0.0.9-full-java8-ibmjava-ubi
+21.0.0.9-full-java11-openj9-ubi
+```
+
+## 21.0.0.6
+
+```
+21.0.0.6-kernel-java8-openj9-ubi
+21.0.0.6-kernel-java8-ibmjava-ubi
+21.0.0.6-kernel-java11-openj9-ubi
+
+21.0.0.6-full-java8-openj9-ubi
+21.0.0.6-full-java8-ibmjava-ubi
+21.0.0.6-full-java11-openj9-ubi
+```

--- a/ga/21.0.0.11/README.md
+++ b/ga/21.0.0.11/README.md
@@ -1,6 +1,6 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty Image
 
-Under this directory you can find build scripts for Docker images (Dockerfiles) for WebSphere Application Server Liberty. Currently resources are available for:
+Under this directory you can find build scripts for WebSphere Application Server Liberty container images:
 
 * [WebSphere Application Server Developer Edition Liberty, Kernel](kernel)
 * [WebSphere Application Server Developer Edition Liberty, Full](full)

--- a/ga/21.0.0.11/full/README.md
+++ b/ga/21.0.0.11/full/README.md
@@ -1,7 +1,7 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty Image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:full` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Liberty with an extensive set of features for convenience.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.

--- a/ga/21.0.0.11/kernel/README.md
+++ b/ga/21.0.0.11/kernel/README.md
@@ -1,9 +1,9 @@
-# WebSphere Application Server Developer Edition Liberty kernel image for Docker
+# WebSphere Application Server Developer Edition Liberty kernel image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:kernel` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition Liberty Kernel and an IBM Java Runtime Environment.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.
 
 **Note:** Refer to [Optional Enterprise Functionality](https://github.com/WASdev/ci.docker#optional-enterprise-functionality) to ensure certain features are enabled such as monitoring or SSL.

--- a/ga/21.0.0.11/oidcProvider/README.md
+++ b/ga/21.0.0.11/oidcProvider/README.md
@@ -1,4 +1,4 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
 The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:oidcProvider` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/).
 

--- a/ga/21.0.0.6/README.md
+++ b/ga/21.0.0.6/README.md
@@ -1,6 +1,6 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
-Under this directory you can find build scripts for Docker images (Dockerfiles) for WebSphere Application Server Liberty. Currently resources are available for:
+Under this directory you can find build scripts for WebSphere Application Server Liberty container images:
 
 * [WebSphere Application Server Developer Edition Liberty, Kernel](kernel)
 * [WebSphere Application Server Developer Edition Liberty, Full](full)

--- a/ga/21.0.0.6/full/README.md
+++ b/ga/21.0.0.6/full/README.md
@@ -4,4 +4,4 @@ The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory i
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.

--- a/ga/21.0.0.6/kernel/README.md
+++ b/ga/21.0.0.6/kernel/README.md
@@ -1,9 +1,9 @@
-# WebSphere Application Server Developer Edition Liberty kernel image for Docker
+# WebSphere Application Server Developer Edition Liberty kernel image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:kernel` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition Liberty Kernel and an IBM Java Runtime Environment.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.
 
 **Note:** Refer to [Optional Enterprise Functionality](https://github.com/WASdev/ci.docker#optional-enterprise-functionality) to ensure certain features are enabled such as monitoring or SSL.

--- a/ga/21.0.0.6/oidcProvider/README.md
+++ b/ga/21.0.0.6/oidcProvider/README.md
@@ -1,4 +1,4 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
 The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:oidcProvider` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/).
 

--- a/ga/21.0.0.9/README.md
+++ b/ga/21.0.0.9/README.md
@@ -1,6 +1,6 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
-Under this directory you can find build scripts for Docker images (Dockerfiles) for WebSphere Application Server Liberty. Currently resources are available for:
+Under this directory you can find build scripts for WebSphere Application Server Liberty container images:
 
 * [WebSphere Application Server Developer Edition Liberty, Kernel](kernel)
 * [WebSphere Application Server Developer Edition Liberty, Full](full)

--- a/ga/21.0.0.9/full/README.md
+++ b/ga/21.0.0.9/full/README.md
@@ -1,7 +1,7 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:full` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Liberty with an extensive set of features for convenience.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.

--- a/ga/21.0.0.9/kernel/README.md
+++ b/ga/21.0.0.9/kernel/README.md
@@ -1,9 +1,9 @@
-# WebSphere Application Server Developer Edition Liberty kernel image for Docker
+# WebSphere Application Server Developer Edition Liberty kernel image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:kernel` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition Liberty Kernel and an IBM Java Runtime Environment.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.
 
 **Note:** Refer to [Optional Enterprise Functionality](https://github.com/WASdev/ci.docker#optional-enterprise-functionality) to ensure certain features are enabled such as monitoring or SSL.

--- a/ga/21.0.0.9/oidcProvider/README.md
+++ b/ga/21.0.0.9/oidcProvider/README.md
@@ -1,4 +1,4 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
 The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:oidcProvider` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/).
 

--- a/ga/README.md
+++ b/ga/README.md
@@ -1,7 +1,3 @@
-# WebSphere Application Server Liberty and Docker
+# WebSphere Application Server Liberty Container Images
 
-Under this directory you can find build scripts for Docker images (Dockerfiles) for WebSphere Application Server Liberty. Currently resources are available for:
-
-* [Dockerfiles](latest) for the latest (19.0.0.12) Docker Hub image.
-* [Dockerfiles](20.0.0.3) for 20.0.0.3 Docker Hub image.
-* [Dockerfiles](19.0.0.12) for 19.0.0.12 Docker Hub image.
+Under this directory you can find build scripts for WebSphere Application Server Liberty container images for latest fix pack and the last two quarterly releases.

--- a/ga/latest/README.md
+++ b/ga/latest/README.md
@@ -1,6 +1,6 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
-Under this directory you can find build scripts for Docker images (Dockerfiles) for WebSphere Application Server Liberty. Currently resources are available for:
+Under this directory you can find build scripts for WebSphere Application Server Liberty container images:
 
 * [WebSphere Application Server Developer Edition Liberty, Kernel](kernel)
 * [WebSphere Application Server Developer Edition Liberty, Full](full)

--- a/ga/latest/full/README.md
+++ b/ga/latest/full/README.md
@@ -1,7 +1,7 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:full` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Liberty with an extensive set of features for convenience.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/full` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.

--- a/ga/latest/kernel/README.md
+++ b/ga/latest/kernel/README.md
@@ -1,9 +1,9 @@
-# WebSphere Application Server Developer Edition Liberty kernel image for Docker
+# WebSphere Application Server Developer Edition Liberty kernel image
 
 The [Dockerfile.ubuntu.ibmjava8](Dockerfile.ubuntu.ibmjava8) in this directory is used to build the `websphere-liberty:kernel` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). The image contains IBM WebSphere Application Server Developer Edition Liberty Kernel and an IBM Java Runtime Environment.
 
 # Usage
 
-Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command `docker build .`.
+Instructions for using the image can be found on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/). It is possible to build the image yourself by cloning this repository, changing to the `ga/<version>/kernel` directory and then issuing the command to build container image. For example, with Docker execute `docker build .`.
 
 **Note:** Refer to [Optional Enterprise Functionality](https://github.com/WASdev/ci.docker#optional-enterprise-functionality) to ensure certain features are enabled such as monitoring or SSL.

--- a/ga/latest/oidcProvider/README.md
+++ b/ga/latest/oidcProvider/README.md
@@ -1,4 +1,4 @@
-# WebSphere Application Server Developer Edition Liberty image for Docker
+# WebSphere Application Server Developer Edition Liberty image
 
 The [Dockerfile](Dockerfile) in this directory is used to build the `websphere-liberty:oidcProvider` image on [Docker Hub](https://registry.hub.docker.com/_/websphere-liberty/).
 

--- a/ga/production-upgrade/README.md
+++ b/ga/production-upgrade/README.md
@@ -1,6 +1,6 @@
-# Using WebSphere Liberty Docker in production
+# Using WebSphere Liberty container images in production
 
-Starting with WebSphere Liberty 18.0.0.3, the WebSphere Liberty Docker images found in Docker Hub contain an International License Agreement for Non-Warranted Programs (ILAN) license which **allows entitled** WebSphere Liberty customers to use these same images under an International Program License Agreement (IPLA) term.
+Starting with WebSphere Liberty 18.0.0.3, the WebSphere Liberty container images contain an International License Agreement for Non-Warranted Programs (ILAN) license which **allows entitled** WebSphere Liberty customers to use these same images under an International Program License Agreement (IPLA) term.
 
 If you want to omit the "development-only" message from the logs all you have to do is set the environment variable called `LICENSE` to the value `accept`.  
 

--- a/test/build.sh
+++ b/test/build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #####################################################################################
 #                                                                                   #
-#  Script to build a docker image                                                   #
+#  Script to build a container image                                                   #
 #                                                                                   #
 #                                                                                   #
 #  Usage : build.sh <Image name> <Dockerfile location> <optional: dockerfile name>  #

--- a/test/buildAll.sh
+++ b/test/buildAll.sh
@@ -15,7 +15,7 @@
 
 #####################################################################################
 #                                                                                   #
-#  Script to build and test all websphere-liberty Docker images                     #
+#  Script to build and test all websphere-liberty container images                     #
 #                                                                                   #
 #                                                                                   #
 #  Usage : buildAll.sh <Release Version>  						                              # 


### PR DESCRIPTION
- Document the images in IBM Container Registry (icr.io) 
- Replace references to Docker with container

Signed-off-by: leochr <leojc@ca.ibm.com>