### PR TITLE
Provide a Dockerfile for WebSphere Liberty with ubuntu and Java 17

### DIFF
--- a/ga/21.0.0.12/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/21.0.0.12/full/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,31 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM websphere-liberty:21.0.0.12-kernel-java17-openj9
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && find /opt/ibm/wlp/output ! -perm -g=rwx -print0 | xargs -0 -r chmod g+rwx

--- a/ga/21.0.0.12/images.txt
+++ b/ga/21.0.0.12/images.txt
@@ -1,10 +1,12 @@
 websphere-liberty:21.0.0.12-kernel                      ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:21.0.0.12-kernel-java11-openj9        ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubuntu.openjdk11
+websphere-liberty:21.0.0.12-kernel-java17-openj9        ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubuntu.openjdk17
 websphere-liberty:21.0.0.12-kernel-java8-ibmjava-ubi    ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.ibmjava8
 websphere-liberty:21.0.0.12-kernel-java8-openj9-ubi     ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk8
 websphere-liberty:21.0.0.12-kernel-java11-openj9-ubi    ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk11
 websphere-liberty:21.0.0.12-full                        ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:21.0.0.12-full-java11-openj9          ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubuntu.openjdk11
+websphere-liberty:21.0.0.12-full-java17-openj9          ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubuntu.openjdk17
 websphere-liberty:21.0.0.12-full-java8-ibmjava-ubi      ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.ibmjava8
 websphere-liberty:21.0.0.12-full-java8-openj9-ubi       ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.openjdk8
 websphere-liberty:21.0.0.12-full-java11-openj9-ubi      ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.openjdk11

--- a/ga/21.0.0.12/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/21.0.0.12/kernel/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,126 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ibm-semeru-runtimes:open-17-jre-focal
+
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+ARG EN_SHA=3e0b8b39a5c8000b0ad1458943454d8ad2e4b4712030cd0f96846a0aa1090078
+ARG NON_IBM_SHA=66d73b0d3e0cb314134e9fee966dbda6c388bf33645583921f63e00851242ff2
+ARG NOTICES_SHA=30a37bfd567f61c63daf4726d95ee3bf6d1c5f2b885678af4d52e44fa2f93e54
+
+LABEL org.opencontainers.image.authors="Chris Potter, Christy Jesuraj, Melissa Lee" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="21.0.0.12" \
+      org.opencontainers.image.revision="cl21.0.0.12920-1900" \
+      org.opencontainers.image.description="This image contains the WebSphere Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image" \
+      org.opencontainers.image.title="IBM WebSphere Liberty"
+
+# Install WebSphere Liberty
+ENV LIBERTY_VERSION 21.0.0_12
+
+ARG LIBERTY_URL
+ARG DOWNLOAD_OPTIONS=""
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip wget openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /licenses/ \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
+    && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && unzip -q /tmp/wlp.zip -d /opt/ibm \
+    && rm /tmp/wlp.zip \
+    && chown -R 1001:0 /opt/ibm/wlp \
+    && chmod -R g+rw /opt/ibm/wlp \
+    && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
+    && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
+    && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
+    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \
+    && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
+    && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
+    && apt-get purge --auto-remove -y unzip \
+    && apt-get purge --auto-remove -y wget \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/ibm/wlp/bin:/opt/ibm/helpers/build:$PATH
+
+# Add labels for consumption by IBM Product Insights
+LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
+      "ProductName"="WebSphere Application Server Liberty" \
+      "ProductVersion"="21.0.0.12" \
+      "BuildLabel"="cl21.0.0.12920-1900"
+
+# Set Path Shortcuts
+ENV LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure WebSphere Liberty
+RUN /opt/ibm/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+COPY helpers/ /opt/ibm/helpers/
+COPY fixes/ /opt/ibm/fixes/
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir /etc/wlp \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+    && mkdir -p /home/default \
+    && mkdir /output \
+    && chmod -t /output \
+    && rm -rf /output \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
+    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /opt/ibm/helpers \
+    && chmod -R g+rwx /opt/ibm/helpers \
+    && chown -R 1001:0 /opt/ibm/fixes \
+    && chmod -R g+rwx /opt/ibm/fixes \
+    && chown -R 1001:0 /opt/ibm/wlp/usr \
+    && chmod -R g+rw /opt/ibm/wlp/usr \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rw /opt/ibm/wlp/output \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ibm/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/ga/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,31 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM websphere-liberty:22.0.0.1-kernel-java17-openj9
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && find /opt/ibm/wlp/output ! -perm -g=rwx -print0 | xargs -0 -r chmod g+rwx

--- a/ga/22.0.0.1/images.txt
+++ b/ga/22.0.0.1/images.txt
@@ -1,10 +1,12 @@
 websphere-liberty:22.0.0.1-kernel                      ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:22.0.0.1-kernel-java11-openj9        ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubuntu.openjdk11
+websphere-liberty:22.0.0.1-kernel-java17-openj9        ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
 websphere-liberty:22.0.0.1-kernel-java8-ibmjava-ubi    ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.ibmjava8
 websphere-liberty:22.0.0.1-kernel-java8-openj9-ubi     ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk8
 websphere-liberty:22.0.0.1-kernel-java11-openj9-ubi    ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk11
 websphere-liberty:22.0.0.1-full                        ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:22.0.0.1-full-java11-openj9          ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubuntu.openjdk11
+websphere-liberty:22.0.0.1-full-java17-openj9          ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
 websphere-liberty:22.0.0.1-full-java8-ibmjava-ubi      ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.ibmjava8
 websphere-liberty:22.0.0.1-full-java8-openj9-ubi       ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.openjdk8
 websphere-liberty:22.0.0.1-full-java11-openj9-ubi      ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.openjdk11

--- a/ga/22.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/22.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,126 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ibm-semeru-runtimes:open-17-jre-focal
+
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+ARG EN_SHA=4889b338a814eb953faba1135d105046ae7d7a62eaf75fb05804214b9fd8ef3a
+ARG NON_IBM_SHA=8f56725d48ec762b9b270c3bf34fba5b67472f0e1d8d0326a6a25483d363bc9c
+ARG NOTICES_SHA=73325d908f5c8d24cba975c429c58bf7f631a947ddc206b1081f2c347e30bff1
+
+LABEL org.opencontainers.image.authors="Chris Potter, Christy Jesuraj, Melissa Lee" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="22.0.0.1" \
+      org.opencontainers.image.revision="cl22.0.0.1920-1900" \
+      org.opencontainers.image.description="This image contains the WebSphere Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image" \
+      org.opencontainers.image.title="IBM WebSphere Liberty"
+
+# Install WebSphere Liberty
+ENV LIBERTY_VERSION 22.0.0_01
+
+ARG LIBERTY_URL
+ARG DOWNLOAD_OPTIONS=""
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip wget openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /licenses/ \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
+    && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && unzip -q /tmp/wlp.zip -d /opt/ibm \
+    && rm /tmp/wlp.zip \
+    && chown -R 1001:0 /opt/ibm/wlp \
+    && chmod -R g+rw /opt/ibm/wlp \
+    && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
+    && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
+    && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
+    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \
+    && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
+    && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
+    && apt-get purge --auto-remove -y unzip \
+    && apt-get purge --auto-remove -y wget \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/ibm/wlp/bin:/opt/ibm/helpers/build:$PATH
+
+# Add labels for consumption by IBM Product Insights
+LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
+      "ProductName"="WebSphere Application Server Liberty" \
+      "ProductVersion"="22.0.0.1" \
+      "BuildLabel"="cl22.0.0.1920-1900"
+
+# Set Path Shortcuts
+ENV LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure WebSphere Liberty
+RUN /opt/ibm/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+COPY helpers/ /opt/ibm/helpers/
+COPY fixes/ /opt/ibm/fixes/
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir /etc/wlp \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+    && mkdir -p /home/default \
+    && mkdir /output \
+    && chmod -t /output \
+    && rm -rf /output \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
+    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /opt/ibm/helpers \
+    && chmod -R g+rwx /opt/ibm/helpers \
+    && chown -R 1001:0 /opt/ibm/fixes \
+    && chmod -R g+rwx /opt/ibm/fixes \
+    && chown -R 1001:0 /opt/ibm/wlp/usr \
+    && chmod -R g+rw /opt/ibm/wlp/usr \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rw /opt/ibm/wlp/output \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ibm/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]

--- a/ga/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/full/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,31 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM websphere-liberty:kernel-java17-openj9
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && find /opt/ibm/wlp/output ! -perm -g=rwx -print0 | xargs -0 -r chmod g+rwx

--- a/ga/latest/images.txt
+++ b/ga/latest/images.txt
@@ -1,10 +1,12 @@
 websphere-liberty:kernel                      ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:kernel-java11-openj9        ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubuntu.openjdk11
+websphere-liberty:kernel-java17-openj9        ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubuntu.openjdk17
 websphere-liberty:kernel-java8-ibmjava-ubi    ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.ibmjava8
 websphere-liberty:kernel-java8-openj9-ubi     ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.openjdk8
 websphere-liberty:kernel-java11-openj9-ubi    ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.openjdk11
 websphere-liberty:full                        ../ga/latest/full       ../ga/latest/full/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:full-java11-openj9          ../ga/latest/full       ../ga/latest/full/Dockerfile.ubuntu.openjdk11
+websphere-liberty:full-java17-openj9          ../ga/latest/full       ../ga/latest/full/Dockerfile.ubuntu.openjdk17
 websphere-liberty:full-java8-ibmjava-ubi      ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.ibmjava8
 websphere-liberty:full-java8-openj9-ubi       ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.openjdk8
 websphere-liberty:full-java11-openj9-ubi      ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.openjdk11

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
@@ -1,0 +1,126 @@
+# (C) Copyright IBM Corporation 2020.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ibm-semeru-runtimes:open-17-jre-focal
+
+ARG VERBOSE=false
+ARG OPENJ9_SCC=true
+ARG EN_SHA=4889b338a814eb953faba1135d105046ae7d7a62eaf75fb05804214b9fd8ef3a
+ARG NON_IBM_SHA=8f56725d48ec762b9b270c3bf34fba5b67472f0e1d8d0326a6a25483d363bc9c
+ARG NOTICES_SHA=73325d908f5c8d24cba975c429c58bf7f631a947ddc206b1081f2c347e30bff1
+
+LABEL org.opencontainers.image.authors="Chris Potter, Christy Jesuraj, Melissa Lee" \
+      org.opencontainers.image.vendor="IBM" \
+      org.opencontainers.image.url="http://wasdev.net" \
+      org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
+      org.opencontainers.image.version="22.0.0.1" \
+      org.opencontainers.image.revision="cl22.0.0.1920-1900" \
+      org.opencontainers.image.description="This image contains the WebSphere Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Ubuntu as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image" \
+      org.opencontainers.image.title="IBM WebSphere Liberty"
+
+# Install WebSphere Liberty
+ENV LIBERTY_VERSION 22.0.0_01
+
+ARG LIBERTY_URL
+ARG DOWNLOAD_OPTIONS=""
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip wget openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /licenses/ \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && LIBERTY_URL=${LIBERTY_URL:-$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*kernel:\s//p' | tr -d '\r' )}  \
+    && wget $DOWNLOAD_OPTIONS $LIBERTY_URL -U UA-IBM-WebSphere-Liberty-Docker -O /tmp/wlp.zip \
+    && unzip -q /tmp/wlp.zip -d /opt/ibm \
+    && rm /tmp/wlp.zip \
+    && chown -R 1001:0 /opt/ibm/wlp \
+    && chmod -R g+rw /opt/ibm/wlp \
+    && LICENSE_BASE=$(wget -q -O - https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml  | grep $LIBERTY_VERSION -A 6 | sed -n 's/\s*license:\s//p' | sed 's/\(.*\)\/.*/\1\//' | tr -d '\r') \
+    && wget ${LICENSE_BASE}en.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/en.html \
+    && wget ${LICENSE_BASE}non_ibm_license.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/non_ibm_license.html \
+    && wget ${LICENSE_BASE}notices.html -U UA-IBM-WebSphere-Liberty-Docker -O /licenses/notices.html \
+    && echo "$EN_SHA /licenses/en.html" | sha256sum -c --strict --check \
+    && echo "$NON_IBM_SHA /licenses/non_ibm_license.html" | sha256sum -c --strict --check \
+    && echo "$NOTICES_SHA /licenses/notices.html" | sha256sum -c --strict --check \
+    && apt-get purge --auto-remove -y unzip \
+    && apt-get purge --auto-remove -y wget \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/ibm/wlp/bin:/opt/ibm/helpers/build:$PATH
+
+# Add labels for consumption by IBM Product Insights
+LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
+      "ProductName"="WebSphere Application Server Liberty" \
+      "ProductVersion"="22.0.0.1" \
+      "BuildLabel"="cl22.0.0.1920-1900"
+
+# Set Path Shortcuts
+ENV LOG_DIR=/logs \
+    WLP_OUTPUT_DIR=/opt/ibm/wlp/output \
+    OPENJ9_SCC=$OPENJ9_SCC
+
+# Configure WebSphere Liberty
+RUN /opt/ibm/wlp/bin/server create \
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+COPY helpers/ /opt/ibm/helpers/
+COPY fixes/ /opt/ibm/fixes/
+
+# Create symlinks && set permissions for non-root user
+RUN mkdir /logs \
+    && mkdir /etc/wlp \
+    && mkdir -p /opt/ibm/wlp/usr/shared/resources/lib.index.cache \
+    && mkdir -p /home/default \
+    && mkdir /output \
+    && chmod -t /output \
+    && rm -rf /output \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
+    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /opt/ibm/helpers \
+    && chmod -R g+rwx /opt/ibm/helpers \
+    && chown -R 1001:0 /opt/ibm/fixes \
+    && chmod -R g+rwx /opt/ibm/fixes \
+    && chown -R 1001:0 /opt/ibm/wlp/usr \
+    && chmod -R g+rw /opt/ibm/wlp/usr \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rw /opt/ibm/wlp/output \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && chown -R 1001:0 /home/default \
+    && chmod -R g+rw /home/default
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && chown -R 1001:0 /opt/ibm/wlp/output \
+    && chmod -R g+rwx /opt/ibm/wlp/output
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false"
+
+USER 1001
+
+EXPOSE 9080 9443
+
+ENTRYPOINT ["/opt/ibm/helpers/runtime/docker-server.sh"]
+CMD ["/opt/ibm/wlp/bin/server", "run", "defaultServer"]


### PR DESCRIPTION
This PR adds the Dockerfile.ubuntu.openjdk17 files to build a container image with WebSphere Liberty and Java 17 (full, kernel)