### PR TITLE
Provide a Dockerfile for WebSphere Liberty with icr.io UBI images and Java 17

### DIFF
--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
@@ -1,0 +1,31 @@
+# (C) Copyright IBM Corporation 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM icr.io/appcafe/websphere-liberty:21.0.0.12-kernel-java17-openj9-ubi
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && find /opt/ibm/wlp/output ! -perm -g=rwx -print0 | xargs -0 -r chmod g+rwx

--- a/ga/21.0.0.12/images.txt
+++ b/ga/21.0.0.12/images.txt
@@ -4,12 +4,14 @@ websphere-liberty:21.0.0.12-kernel-java17-openj9        ../ga/21.0.0.12/kernel  
 websphere-liberty:21.0.0.12-kernel-java8-ibmjava-ubi    ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.ibmjava8
 websphere-liberty:21.0.0.12-kernel-java8-openj9-ubi     ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk8
 websphere-liberty:21.0.0.12-kernel-java11-openj9-ubi    ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk11
+websphere-liberty:21.0.0.12-kernel-java17-openj9-ubi    ../ga/21.0.0.12/kernel     ../ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk17
 websphere-liberty:21.0.0.12-full                        ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:21.0.0.12-full-java11-openj9          ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubuntu.openjdk11
 websphere-liberty:21.0.0.12-full-java17-openj9          ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubuntu.openjdk17
 websphere-liberty:21.0.0.12-full-java8-ibmjava-ubi      ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.ibmjava8
 websphere-liberty:21.0.0.12-full-java8-openj9-ubi       ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.openjdk8
 websphere-liberty:21.0.0.12-full-java11-openj9-ubi      ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.openjdk11
+websphere-liberty:21.0.0.12-full-java17-openj9-ubi      ../ga/21.0.0.12/full       ../ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
 websphere-liberty:beta                        ../beta
 websphere-liberty:test-stock-quote            test-stock-quote
 websphere-liberty:test-stock-trader           test-stock-trader

--- a/ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk17
@@ -20,7 +20,7 @@ ARG EN_SHA=3e0b8b39a5c8000b0ad1458943454d8ad2e4b4712030cd0f96846a0aa1090078
 ARG NON_IBM_SHA=66d73b0d3e0cb314134e9fee966dbda6c388bf33645583921f63e00851242ff2
 ARG NOTICES_SHA=30a37bfd567f61c63daf4726d95ee3bf6d1c5f2b885678af4d52e44fa2f93e54
 
-LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Arthur De Magalhaes, Chris Potter" \
+LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Chris Potter, Melissa Lee" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \

--- a/ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/21.0.0.12/kernel/Dockerfile.ubi.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/21.0.0.9/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/21.0.0.9/kernel/Dockerfile.ubi.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/21.0.0.9/kernel/Dockerfile.ubi.openjdk8
+++ b/ga/21.0.0.9/kernel/Dockerfile.ubi.openjdk8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
@@ -1,0 +1,31 @@
+# (C) Copyright IBM Corporation 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM icr.io/appcafe/websphere-liberty:22.0.0.1-kernel-java17-openj9-ubi
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && find /opt/ibm/wlp/output ! -perm -g=rwx -print0 | xargs -0 -r chmod g+rwx

--- a/ga/22.0.0.1/images.txt
+++ b/ga/22.0.0.1/images.txt
@@ -4,12 +4,14 @@ websphere-liberty:22.0.0.1-kernel-java17-openj9        ../ga/22.0.0.1/kernel    
 websphere-liberty:22.0.0.1-kernel-java8-ibmjava-ubi    ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.ibmjava8
 websphere-liberty:22.0.0.1-kernel-java8-openj9-ubi     ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk8
 websphere-liberty:22.0.0.1-kernel-java11-openj9-ubi    ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk11
+websphere-liberty:22.0.0.1-kernel-java17-openj9-ubi    ../ga/22.0.0.1/kernel     ../ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk17
 websphere-liberty:22.0.0.1-full                        ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:22.0.0.1-full-java11-openj9          ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubuntu.openjdk11
 websphere-liberty:22.0.0.1-full-java17-openj9          ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubuntu.openjdk17
 websphere-liberty:22.0.0.1-full-java8-ibmjava-ubi      ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.ibmjava8
 websphere-liberty:22.0.0.1-full-java8-openj9-ubi       ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.openjdk8
 websphere-liberty:22.0.0.1-full-java11-openj9-ubi      ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.openjdk11
+websphere-liberty:22.0.0.1-full-java17-openj9-ubi      ../ga/22.0.0.1/full       ../ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
 websphere-liberty:beta                        ../beta
 websphere-liberty:test-stock-quote            test-stock-quote
 websphere-liberty:test-stock-trader           test-stock-trader

--- a/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk17
@@ -12,28 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true
-ARG EN_SHA=3e0b8b39a5c8000b0ad1458943454d8ad2e4b4712030cd0f96846a0aa1090078
-ARG NON_IBM_SHA=66d73b0d3e0cb314134e9fee966dbda6c388bf33645583921f63e00851242ff2
-ARG NOTICES_SHA=30a37bfd567f61c63daf4726d95ee3bf6d1c5f2b885678af4d52e44fa2f93e54
+ARG EN_SHA=4889b338a814eb953faba1135d105046ae7d7a62eaf75fb05804214b9fd8ef3a
+ARG NON_IBM_SHA=8f56725d48ec762b9b270c3bf34fba5b67472f0e1d8d0326a6a25483d363bc9c
+ARG NOTICES_SHA=73325d908f5c8d24cba975c429c58bf7f631a947ddc206b1081f2c347e30bff1
 
 LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
-      org.opencontainers.image.version="21.0.0.12" \
-      org.opencontainers.image.revision="cl21.0.0.12920-1900" \
+      org.opencontainers.image.version="22.0.0.1" \
+      org.opencontainers.image.revision="cl22.0.0.1920-1900" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
-      version="21.0.0.12" \
+      version="22.0.0.1" \
       summary="Image for WebSphere Liberty with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Red Hat's UBI 8" \
       description="This image contains the WebSphere Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
-ENV LIBERTY_VERSION 21.0.0_12
+ENV LIBERTY_VERSION 22.0.0_01
 
 ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
@@ -64,8 +64,8 @@ ENV PATH=/opt/ibm/wlp/bin:/opt/ibm/helpers/build:$PATH
 # Add labels for consumption by IBM Product Insights
 LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
       "ProductName"="WebSphere Application Server Liberty" \
-      "ProductVersion"="21.0.0.12" \
-      "BuildLabel"="cl21.0.0.12920-1900"
+      "ProductVersion"="22.0.0.1" \
+      "BuildLabel"="cl22.0.0.1920-1900"
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \

--- a/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk17
@@ -20,7 +20,7 @@ ARG EN_SHA=4889b338a814eb953faba1135d105046ae7d7a62eaf75fb05804214b9fd8ef3a
 ARG NON_IBM_SHA=8f56725d48ec762b9b270c3bf34fba5b67472f0e1d8d0326a6a25483d363bc9c
 ARG NOTICES_SHA=73325d908f5c8d24cba975c429c58bf7f631a947ddc206b1081f2c347e30bff1
 
-LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Arthur De Magalhaes, Chris Potter" \
+LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Chris Potter, Melissa Lee" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \

--- a/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk8
+++ b/ga/22.0.0.1/kernel/Dockerfile.ubi.openjdk8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/latest/full/Dockerfile.ubi.openjdk17
+++ b/ga/latest/full/Dockerfile.ubi.openjdk17
@@ -1,0 +1,31 @@
+# (C) Copyright IBM Corporation 2019.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM icr.io/appcafe/websphere-liberty:kernel-java17-openj9-ubi
+ARG VERBOSE=false
+ARG REPOSITORIES_PROPERTIES=""
+
+RUN if [ ! -z $REPOSITORIES_PROPERTIES ]; then mkdir /opt/ibm/wlp/etc/ \
+  && echo $REPOSITORIES_PROPERTIES > /opt/ibm/wlp/etc/repositories.properties; fi \
+  && installUtility install --acceptLicense baseBundle \
+  && if [ ! -z $REPOSITORIES_PROPERTIES ]; then rm /opt/ibm/wlp/etc/repositories.properties; fi \
+  && rm -rf /output/workarea /output/logs \
+  && find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
+
+COPY --chown=1001:0 server.xml /config/
+
+# Create a new SCC layer
+RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi \
+    && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache \
+    && find /opt/ibm/wlp/output ! -perm -g=rwx -print0 | xargs -0 -r chmod g+rwx

--- a/ga/latest/images.txt
+++ b/ga/latest/images.txt
@@ -4,12 +4,14 @@ websphere-liberty:kernel-java17-openj9        ../ga/latest/kernel     ../ga/late
 websphere-liberty:kernel-java8-ibmjava-ubi    ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.ibmjava8
 websphere-liberty:kernel-java8-openj9-ubi     ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.openjdk8
 websphere-liberty:kernel-java11-openj9-ubi    ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.openjdk11
+websphere-liberty:kernel-java17-openj9-ubi    ../ga/latest/kernel     ../ga/latest/kernel/Dockerfile.ubi.openjdk17
 websphere-liberty:full                        ../ga/latest/full       ../ga/latest/full/Dockerfile.ubuntu.ibmjava8
 websphere-liberty:full-java11-openj9          ../ga/latest/full       ../ga/latest/full/Dockerfile.ubuntu.openjdk11
 websphere-liberty:full-java17-openj9          ../ga/latest/full       ../ga/latest/full/Dockerfile.ubuntu.openjdk17
 websphere-liberty:full-java8-ibmjava-ubi      ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.ibmjava8
 websphere-liberty:full-java8-openj9-ubi       ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.openjdk8
 websphere-liberty:full-java11-openj9-ubi      ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.openjdk11
+websphere-liberty:full-java17-openj9-ubi      ../ga/latest/full       ../ga/latest/full/Dockerfile.ubi.openjdk17
 websphere-liberty:beta                        ../beta
 websphere-liberty:test-stock-quote            test-stock-quote
 websphere-liberty:test-stock-trader           test-stock-trader

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-11-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk17
@@ -12,28 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true
-ARG EN_SHA=3e0b8b39a5c8000b0ad1458943454d8ad2e4b4712030cd0f96846a0aa1090078
-ARG NON_IBM_SHA=66d73b0d3e0cb314134e9fee966dbda6c388bf33645583921f63e00851242ff2
-ARG NOTICES_SHA=30a37bfd567f61c63daf4726d95ee3bf6d1c5f2b885678af4d52e44fa2f93e54
+ARG EN_SHA=4889b338a814eb953faba1135d105046ae7d7a62eaf75fb05804214b9fd8ef3a
+ARG NON_IBM_SHA=8f56725d48ec762b9b270c3bf34fba5b67472f0e1d8d0326a6a25483d363bc9c
+ARG NOTICES_SHA=73325d908f5c8d24cba975c429c58bf7f631a947ddc206b1081f2c347e30bff1
 
 LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Arthur De Magalhaes, Chris Potter" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \
-      org.opencontainers.image.version="21.0.0.12" \
-      org.opencontainers.image.revision="cl21.0.0.12920-1900" \
+      org.opencontainers.image.version="22.0.0.1" \
+      org.opencontainers.image.revision="cl22.0.0.1920-1900" \
       vendor="IBM" \
       name="IBM WebSphere Liberty" \
-      version="21.0.0.12" \
+      version="22.0.0.1" \
       summary="Image for WebSphere Liberty with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Red Hat's UBI 8" \
       description="This image contains the WebSphere Liberty runtime with IBM Semeru Runtime Open Edition OpenJDK with OpenJ9 and Red Hat's UBI 8 as the base OS.  For more information on this image please see https://github.com/WASdev/ci.docker#building-an-application-image"
 
 # Install WebSphere Liberty
-ENV LIBERTY_VERSION 21.0.0_12
+ENV LIBERTY_VERSION 22.0.0_01
 
 ARG LIBERTY_URL
 ARG DOWNLOAD_OPTIONS=""
@@ -64,8 +64,8 @@ ENV PATH=/opt/ibm/wlp/bin:/opt/ibm/helpers/build:$PATH
 # Add labels for consumption by IBM Product Insights
 LABEL "ProductID"="fbf6a96d49214c0abc6a3bc5da6e48cd" \
       "ProductName"="WebSphere Application Server Liberty" \
-      "ProductVersion"="21.0.0.12" \
-      "BuildLabel"="cl21.0.0.12920-1900"
+      "ProductVersion"="22.0.0.1" \
+      "BuildLabel"="cl22.0.0.1920-1900"
 
 # Set Path Shortcuts
 ENV LOG_DIR=/logs \

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk17
@@ -20,7 +20,7 @@ ARG EN_SHA=4889b338a814eb953faba1135d105046ae7d7a62eaf75fb05804214b9fd8ef3a
 ARG NON_IBM_SHA=8f56725d48ec762b9b270c3bf34fba5b67472f0e1d8d0326a6a25483d363bc9c
 ARG NOTICES_SHA=73325d908f5c8d24cba975c429c58bf7f631a947ddc206b1081f2c347e30bff1
 
-LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Arthur De Magalhaes, Chris Potter" \
+LABEL org.opencontainers.image.authors="Leo Christy Jesuraj, Chris Potter, Melissa Lee" \
       org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.url="http://wasdev.net" \
       org.opencontainers.image.documentation="https://www.ibm.com/support/knowledgecenter/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/cwlp_about.html" \

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmsemeruruntime/open-8-jdk:ubi-jdk
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
 
 ARG VERBOSE=false
 ARG OPENJ9_SCC=true


### PR DESCRIPTION
This PR adds Dockerfiles to build container images for Open Liberty with icr.io UBI images and Java 17 (full, kernel)
