### PR TITLE
Support dynamically changing parent image

### DIFF
--- a/ga/21.0.0.12/full/Dockerfile.ubi.ibmjava8
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.ibmjava8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.12-kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.ibmjava8
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.ibmjava8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.12-kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk11
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk11
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java11-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.12-kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk11
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk11
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.12-kernel-java11-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.12-kernel-java17-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java17-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk17
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java17-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.12-kernel-java17-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk8
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.12-kernel-java8-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.12/full/Dockerfile.ubi.openjdk8
+++ b/ga/21.0.0.12/full/Dockerfile.ubi.openjdk8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.12-kernel-java8-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.12-kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.9/full/Dockerfile.ubi.ibmjava8
+++ b/ga/21.0.0.9/full/Dockerfile.ubi.ibmjava8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.9-kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.9-kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.9/full/Dockerfile.ubi.ibmjava8
+++ b/ga/21.0.0.9/full/Dockerfile.ubi.ibmjava8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.9-kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.9-kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.9/full/Dockerfile.ubi.openjdk11
+++ b/ga/21.0.0.9/full/Dockerfile.ubi.openjdk11
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.9-kernel-java11-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.9-kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.9/full/Dockerfile.ubi.openjdk11
+++ b/ga/21.0.0.9/full/Dockerfile.ubi.openjdk11
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.9-kernel-java11-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.9-kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.9/full/Dockerfile.ubi.openjdk8
+++ b/ga/21.0.0.9/full/Dockerfile.ubi.openjdk8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:21.0.0.9-kernel-java8-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:21.0.0.9-kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/21.0.0.9/full/Dockerfile.ubi.openjdk8
+++ b/ga/21.0.0.9/full/Dockerfile.ubi.openjdk8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:21.0.0.9-kernel-java8-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:21.0.0.9-kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.ibmjava8
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.ibmjava8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:22.0.0.1-kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.ibmjava8
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.ibmjava8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:22.0.0.1-kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk11
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk11
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java11-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:22.0.0.1-kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk11
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk11
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:22.0.0.1-kernel-java11-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java17-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:22.0.0.1-kernel-java17-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk17
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:22.0.0.1-kernel-java17-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java17-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk8
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java8-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:22.0.0.1-kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/22.0.0.1/full/Dockerfile.ubi.openjdk8
+++ b/ga/22.0.0.1/full/Dockerfile.ubi.openjdk8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:22.0.0.1-kernel-java8-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:22.0.0.1-kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubi.ibmjava8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubi.ibmjava8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:kernel-java8-ibmjava-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:kernel-java8-ibmjava-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk11
+++ b/ga/latest/full/Dockerfile.ubi.openjdk11
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:kernel-java11-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk11
+++ b/ga/latest/full/Dockerfile.ubi.openjdk11
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:kernel-java11-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:kernel-java11-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk17
+++ b/ga/latest/full/Dockerfile.ubi.openjdk17
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:kernel-java17-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:kernel-java17-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk17
+++ b/ga/latest/full/Dockerfile.ubi.openjdk17
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:kernel-java17-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:kernel-java17-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk8
+++ b/ga/latest/full/Dockerfile.ubi.openjdk8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
-FROM $PARENT_IMAGE_REPO:kernel-java8-openj9-ubi
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE:kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk8
+++ b/ga/latest/full/Dockerfile.ubi.openjdk8
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/websphere-liberty:kernel-java8-openj9-ubi
+ARG PARENT_IMAGE_REPO=icr.io/appcafe/websphere-liberty
+FROM $PARENT_IMAGE_REPO:kernel-java8-openj9-ubi
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/test/buildAll.sh
+++ b/test/buildAll.sh
@@ -74,8 +74,8 @@ done < $currentRelease/"images.txt"
 tags=(kernel full)
 for j in "${!tags[@]}"; do 
   echo "${currentRelease}"
-  file_exts_ubi=(ubi.openjdk8 ubi.openjdk11 ubi.ibmjava8)
-  tag_exts_ubi=(java8-openj9-ubi java11-openj9-ubi java8-ibmjava-ubi)
+  file_exts_ubi=(ubi.openjdk8 ubi.openjdk11 ubi.openjdk17 ubi.ibmjava8)
+  tag_exts_ubi=(java8-openj9-ubi java11-openj9-ubi java17-openj9-ubi java8-ibmjava-ubi)
 
   for i in "${!tag_exts_ubi[@]}"; do
       docker_dir="${IMAGE_ROOT}/${tags[$j]}"


### PR DESCRIPTION
- Images are first built in staging environment. Hence the _kernel_ image specified as parent image in Dockerfiles of _full_ images wouldn't exist yet. Allow the parent image to be passed in as a build argument.
Only changed UBI images since we only build them. Ubuntu images are built by Docker Hub, so left them as-is for now.

- Added Java 17 tag to build script.