### PR TITLE
Don't create SCCs on 32-bit IBM Java

### DIFF
--- a/ga/21.0.0.12/kernel/helpers/build/populate_scc.sh
+++ b/ga/21.0.0.12/kernel/helpers/build/populate_scc.sh
@@ -18,6 +18,9 @@ fi
 
 set -Eeox pipefail
 
+# 32-bit JVMs don't supported multi-layered SCCs.
+[ -e "$JAVA_HOME/lib/i386" -o -e "$JAVA_HOME/lib/ppc" -o -e "$JAVA_HOME/lib/s390" ] && exit 0
+
 SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.

--- a/ga/22.0.0.3/kernel/helpers/build/populate_scc.sh
+++ b/ga/22.0.0.3/kernel/helpers/build/populate_scc.sh
@@ -18,6 +18,9 @@ fi
 
 set -Eeox pipefail
 
+# 32-bit JVMs don't supported multi-layered SCCs.
+[ -e "$JAVA_HOME/lib/i386" -o -e "$JAVA_HOME/lib/ppc" -o -e "$JAVA_HOME/lib/s390" ] && exit 0
+
 SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.

--- a/ga/latest/kernel/helpers/build/populate_scc.sh
+++ b/ga/latest/kernel/helpers/build/populate_scc.sh
@@ -18,6 +18,9 @@ fi
 
 set -Eeox pipefail
 
+# 32-bit JVMs don't supported multi-layered SCCs.
+[ -e "$JAVA_HOME/lib/i386" -o -e "$JAVA_HOME/lib/ppc" -o -e "$JAVA_HOME/lib/s390" ] && exit 0
+
 SCC_SIZE="80m"  # Default size of the SCC layer.
 ITERATIONS=2    # Number of iterations to run to populate it.
 TRIM_SCC=yes    # Trim the SCC to eliminate any wasted space.


### PR DESCRIPTION
32-bit IBM Java VMs don't support multi-layered SCCs.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>

Fixes #403