### PR TITLE
Add support for FEATURE_REPO_URL to use on-premises Maven repositories with featureUtility

### DIFF
--- a/ga/22.0.0.10/kernel/helpers/build/configure.sh
+++ b/ga/22.0.0.10/kernel/helpers/build/configure.sh
@@ -119,9 +119,14 @@ function main() {
   if [ "$SKIP_FEATURE_INSTALL" != "true" ]; then
     # Install needed features
     if [ "$FEATURE_REPO_URL" ]; then
-      curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
-      installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
-      rm -rf /tmp/repo.zip
+      if [[ $FEATURE_REPO_URL == *.zip ]]; then
+        curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
+        installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
+        rm -rf /tmp/repo.zip
+      else
+	featureUtility installServerFeatures --acceptLicense defaultServer --noCache
+        find /opt/ibm/wlp/lib /opt/ibm/wlp/bin ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
+      fi
     else
       installUtility install --acceptLicense defaultServer || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
     fi

--- a/ga/22.0.0.9/kernel/helpers/build/configure.sh
+++ b/ga/22.0.0.9/kernel/helpers/build/configure.sh
@@ -119,9 +119,14 @@ function main() {
   if [ "$SKIP_FEATURE_INSTALL" != "true" ]; then
     # Install needed features
     if [ "$FEATURE_REPO_URL" ]; then
-      curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
-      installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
-      rm -rf /tmp/repo.zip
+      if [[ $FEATURE_REPO_URL == *.zip ]]; then
+        curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
+        installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
+        rm -rf /tmp/repo.zip
+      else
+	featureUtility installServerFeatures --acceptLicense defaultServer --noCache
+        find /opt/ibm/wlp/lib /opt/ibm/wlp/bin ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
+      fi
     else
       installUtility install --acceptLicense defaultServer || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
     fi

--- a/ga/22.0.0.9/kernel/helpers/build/configure.sh
+++ b/ga/22.0.0.9/kernel/helpers/build/configure.sh
@@ -119,14 +119,9 @@ function main() {
   if [ "$SKIP_FEATURE_INSTALL" != "true" ]; then
     # Install needed features
     if [ "$FEATURE_REPO_URL" ]; then
-      if [[ $FEATURE_REPO_URL == *.zip ]]; then
-        curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
-        installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
-        rm -rf /tmp/repo.zip
-      else
-	featureUtility installServerFeatures --acceptLicense defaultServer --noCache
-        find /opt/ibm/wlp/lib /opt/ibm/wlp/bin ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
-      fi
+      curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
+      installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
+      rm -rf /tmp/repo.zip
     else
       installUtility install --acceptLicense defaultServer || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
     fi

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -119,9 +119,14 @@ function main() {
   if [ "$SKIP_FEATURE_INSTALL" != "true" ]; then
     # Install needed features
     if [ "$FEATURE_REPO_URL" ]; then
-      curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
-      installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
-      rm -rf /tmp/repo.zip
+      if [[ $FEATURE_REPO_URL == *.zip ]]; then
+        curl -k --fail $FEATURE_REPO_URL > /tmp/repo.zip
+        installUtility install --acceptLicense defaultServer --from=/tmp/repo.zip || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
+        rm -rf /tmp/repo.zip
+      else
+	featureUtility installServerFeatures --acceptLicense defaultServer --noCache
+        find /opt/ibm/wlp/lib /opt/ibm/wlp/bin ! -perm -g=rw -print0 | xargs -0 -r chmod g+rw
+      fi
     else
       installUtility install --acceptLicense defaultServer || rc=$?; if [ $rc -ne 22 ]; then exit $rc; fi
     fi


### PR DESCRIPTION
This change constricts `FEATURE_REPO_URL` to use `installUtility` when the environment variable ends with`*.zip` that indicates an install from Fix Central. When this is not the case, `FEATURE_REPO_URL` should switch to using `featureUtility`, which is compatible with supporting on-premises Maven repositories by design.