### PR TITLE
Enable user to specify size of SCC embedded in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following enterprise functionalities are now **deprecated** and will be **re
   *  XML Snippet Location: [oidc-config.xml](ga/latest/kernel/helpers/build/configuration_snippets/oidc-config.xml)
   *  Note: The following variables will be read:  OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL.
 
-## Security 
+## Security
 
 Single Sign-On can be optionally configured by adding Liberty server variables in an xml file, by passing environment variables (less secure),
 or by passing Liberty server variables in through the Liberty operator. See [SECURITY.md](SECURITY.md).
@@ -108,6 +108,12 @@ This feature can be controlled via the following variables:
 * `OPENJ9_SCC` (environment variable)
   *  Description: If `"true"`, cache application-specific in an SCC and include it in the image. A new SCC will be created if needed, otherwise data will be added to the existing SCC.
   *  Default: `"true"`.
+* `TRIM_SCC` (environment variable)
+  * Description: If `"true"`, the application-specific SCC layer will be sized-down to accomodate only the data populated during image build process. To allow the application to add more data to the SCC at runtime, set this variable to `"false"`, but also ensure the SCC is not marked read-only. This can be done by setting the OPENJ9_JAVA_OPTIONS environment variable in your application Dockerfile like so: `ENV OPENJ9_JAVA_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,nonFatal -Dosgi.checkConfiguration=false"`. Note that OPENJ9_JAVA_OPTIONS is already defined in the base Liberty image dockerfile, but includes the `readonly` sub-option.
+  * Default: `"true"`.
+* `SCC_SIZE` (environment variable)
+  * Description: The size of the application-specific SCC layer in the image. This value is only used if `TRIM_SCC` is set to `"false"`.
+  * Default: `"80m"`.
 
 ## Logging
 

--- a/ga/22.0.0.12/kernel/helpers/build/configure.sh
+++ b/ga/22.0.0.12/kernel/helpers/build/configure.sh
@@ -145,9 +145,15 @@ function main() {
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
 
   # Create a new SCC layer
-  if [ "$OPENJ9_SCC" == "true" ]
-  then
-    populate_scc.sh -i 1
+  if [ "$OPENJ9_SCC" == "true" ]; then
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/ga/22.0.0.9/kernel/helpers/build/configure.sh
+++ b/ga/22.0.0.9/kernel/helpers/build/configure.sh
@@ -145,9 +145,15 @@ function main() {
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
 
   # Create a new SCC layer
-  if [ "$OPENJ9_SCC" == "true" ]
-  then
-    populate_scc.sh -i 1
+  if [ "$OPENJ9_SCC" == "true" ]; then
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/ga/23.0.0.1/kernel/helpers/build/configure.sh
+++ b/ga/23.0.0.1/kernel/helpers/build/configure.sh
@@ -145,9 +145,15 @@ function main() {
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
 
   # Create a new SCC layer
-  if [ "$OPENJ9_SCC" == "true" ]
-  then
-    populate_scc.sh -i 1
+  if [ "$OPENJ9_SCC" == "true" ]; then
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 

--- a/ga/latest/kernel/helpers/build/configure.sh
+++ b/ga/latest/kernel/helpers/build/configure.sh
@@ -145,9 +145,15 @@ function main() {
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw
 
   # Create a new SCC layer
-  if [ "$OPENJ9_SCC" == "true" ]
-  then
-    populate_scc.sh -i 1
+  if [ "$OPENJ9_SCC" == "true" ]; then
+    cmd="populate_scc.sh -i 1"
+    if [ "$TRIM_SCC" == "false" ]; then
+      cmd+=" -d"
+    fi
+    if [ ! "$SCC_SIZE" = "" ]; then
+      cmd+=" -s $SCC_SIZE"
+    fi
+    eval $cmd
   fi
 }
 


### PR DESCRIPTION
Users who create container images for their Liberty based apps are encouraged to use "RUN configure.sh" in the Dockerfile for their containerized app. In turn, this script will call `populate_scc.sh` which will create a shared class cached (SCC) populated with Java classes and methods used during app start-up. Currently, the populate_scc.sh script uses a fixed size (80m) for the embedded SCC. Moreover, the variable `TRIM_SCC` that controls whether or not the SCC is trimmed to just the right size for the classes/methods used during start-up is set to "yes".
To take advantage of the AOT cache from the Semeru Cloud Compiler, the client JVM (which runs a Liberty app) needs to have a SCC with some empty space in it, to be able to add new AOT methods received from the Semeru Cloud Compiler.
This commit allows a user to change the default values for the TRIM_SCC and SCC_SIZE variables in order to create a Liberty app container with an embedded SCC that has some free space. To take advantage of this commit, the user would have to add somethig like
        ENV TRIM_SCC=no
        ENV SCC_SIZE=120m
in his Dockerfile, before calling the `configure.sh` script

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>