### PR TITLE
Add ca.crt to keystore, if it exists

### DIFF
--- a/ga/22.0.0.12/kernel/helpers/runtime/docker-server.sh
+++ b/ga/22.0.0.12/kernel/helpers/runtime/docker-server.sh
@@ -30,12 +30,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
      # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/ga/22.0.0.9/kernel/helpers/runtime/docker-server.sh
+++ b/ga/22.0.0.9/kernel/helpers/runtime/docker-server.sh
@@ -30,12 +30,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
      # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/ga/23.0.0.1/kernel/helpers/runtime/docker-server.sh
+++ b/ga/23.0.0.1/kernel/helpers/runtime/docker-server.sh
@@ -30,12 +30,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
      # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml

--- a/ga/latest/kernel/helpers/runtime/docker-server.sh
+++ b/ga/latest/kernel/helpers/runtime/docker-server.sh
@@ -30,12 +30,22 @@ function importKeyCert() {
   if [ -f "${CERT_FOLDER}/${KEY_FILE}" ] && [ -f "${CERT_FOLDER}/${CRT_FILE}" ]; then
     echo "Found mounted TLS certificates, generating keystore"
     mkdir -p /output/resources/security
-    openssl pkcs12 -export \
-      -name "defaultKeyStore" \
-      -inkey "${CERT_FOLDER}/${KEY_FILE}" \
-      -in "${CERT_FOLDER}/${CRT_FILE}" \
-      -out "${KEYSTORE_FILE}" \
-      -password pass:"${PASSWORD}" >&/dev/null
+    if [ -f "${CERT_FOLDER}/${CA_FILE}" ]; then
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -certfile "${CERT_FOLDER}/${CA_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    else
+      openssl pkcs12 -export \
+        -name "defaultKeyStore" \
+        -inkey "${CERT_FOLDER}/${KEY_FILE}" \
+        -in "${CERT_FOLDER}/${CRT_FILE}" \
+        -out "${KEYSTORE_FILE}" \
+        -password pass:"${PASSWORD}" >&/dev/null
+    fi
 
      # Since we are creating new keystore, always write new password to a file
     sed "s|REPLACE|$PASSWORD|g" $SNIPPETS_SOURCE/keystore.xml > $SNIPPETS_TARGET_DEFAULTS/keystore.xml


### PR DESCRIPTION
Currently when keystore is generated from mounted file and root CA is in separate file (ca.crt) the keystore will have incomplete chain
