### PR TITLE
Update Ubuntu full images to use tag in FROM

### DIFF
--- a/ga/23.0.0.6/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/23.0.0.6/full/Dockerfile.ubuntu.ibmjava8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=websphere-liberty:23.0.0.6-kernel-java8-ibmjava
-FROM $PARENT_IMAGE AS installBundle
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:23.0.0.6-kernel-java8-ibmjava AS installBundle
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -35,8 +35,8 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=websphere-liberty:23.0.0.6-kernel-java8-ibmjava
-FROM $PARENT_IMAGE
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:23.0.0.6-kernel-java8-ibmjava
 ARG VERBOSE=false
 
 # Copy the runtime

--- a/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk11
+++ b/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk11
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=websphere-liberty:23.0.0.6-kernel-java11-openj9
-FROM $PARENT_IMAGE AS installBundle
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:23.0.0.6-kernel-java11-openj9 AS installBundle
 
 USER root
 
@@ -38,8 +38,8 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=websphere-liberty:23.0.0.6-kernel-java11-openj9
-FROM $PARENT_IMAGE
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:23.0.0.6-kernel-java11-openj9
 ARG VERBOSE=false
 
 # Copy the runtime

--- a/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk17
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=websphere-liberty:23.0.0.6-kernel-java17-openj9
-FROM $PARENT_IMAGE AS installBundle
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:23.0.0.6-kernel-java17-openj9 AS installBundle
 
 USER root
 
@@ -38,8 +38,8 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=websphere-liberty:23.0.0.6-kernel-java17-openj9
-FROM $PARENT_IMAGE
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:23.0.0.6-kernel-java17-openj9
 ARG VERBOSE=false
 
 # Copy the runtime

--- a/ga/latest/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubuntu.ibmjava8
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=websphere-liberty:kernel
-FROM $PARENT_IMAGE AS installBundle
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:kernel AS installBundle
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -35,8 +35,8 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=websphere-liberty:kernel
-FROM $PARENT_IMAGE
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:kernel
 ARG VERBOSE=false
 
 # Copy the runtime

--- a/ga/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/ga/latest/full/Dockerfile.ubuntu.openjdk11
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=websphere-liberty:kernel-java11-openj9
-FROM $PARENT_IMAGE AS installBundle
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:kernel-java11-openj9 AS installBundle
 
 USER root
 
@@ -38,8 +38,8 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=websphere-liberty:kernel-java11-openj9
-FROM $PARENT_IMAGE
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:kernel-java11-openj9
 ARG VERBOSE=false
 
 # Copy the runtime

--- a/ga/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/full/Dockerfile.ubuntu.openjdk17
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=websphere-liberty:kernel-java17-openj9
-FROM $PARENT_IMAGE AS installBundle
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:kernel-java17-openj9 AS installBundle
 
 USER root
 
@@ -38,8 +38,8 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=websphere-liberty:kernel-java17-openj9
-FROM $PARENT_IMAGE
+ARG PARENT_IMAGE=websphere-liberty
+FROM $PARENT_IMAGE:kernel-java17-openj9
 ARG VERBOSE=false
 
 # Copy the runtime


### PR DESCRIPTION
Seems like there's logic in the Docker builds that appends `:latest` to an image that it thinks doesn't have a tag, which results in it trying to pull down things like `websphere-liberty:kernel-java17-openj9:latest`