### PR TITLE
Remove root user from full images and use chown when copying files

### DIFF
--- a/ga/23.0.0.6/full/Dockerfile.ubi.ibmjava8
+++ b/ga/23.0.0.6/full/Dockerfile.ubi.ibmjava8
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:23.0.0.6-kernel-java8-ibmjava-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/23.0.0.6/full/Dockerfile.ubi.openjdk11
+++ b/ga/23.0.0.6/full/Dockerfile.ubi.openjdk11
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:23.0.0.6-kernel-java11-openj9-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/23.0.0.6/full/Dockerfile.ubi.openjdk17
+++ b/ga/23.0.0.6/full/Dockerfile.ubi.openjdk17
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:23.0.0.6-kernel-java17-openj9-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/23.0.0.6/full/Dockerfile.ubi.openjdk8
+++ b/ga/23.0.0.6/full/Dockerfile.ubi.openjdk8
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:23.0.0.6-kernel-java8-openj9-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/23.0.0.6/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/23.0.0.6/full/Dockerfile.ubuntu.ibmjava8
@@ -14,8 +14,6 @@
 
 FROM websphere-liberty:23.0.0.6-kernel-java8-ibmjava
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk11
+++ b/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk11
@@ -14,8 +14,6 @@
 
 FROM websphere-liberty:23.0.0.6-kernel-java11-openj9
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/23.0.0.6/full/Dockerfile.ubuntu.openjdk17
@@ -14,8 +14,6 @@
 
 FROM websphere-liberty:23.0.0.6-kernel-java17-openj9
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubi.ibmjava8
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java8-ibmjava-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk11
+++ b/ga/latest/full/Dockerfile.ubi.openjdk11
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java11-openj9-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk17
+++ b/ga/latest/full/Dockerfile.ubi.openjdk17
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java17-openj9-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk8
+++ b/ga/latest/full/Dockerfile.ubi.openjdk8
@@ -15,8 +15,6 @@
 ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java8-openj9-ubi
 FROM $PARENT_IMAGE AS installBundle
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 
@@ -43,7 +41,7 @@ FROM $PARENT_IMAGE
 ARG VERBOSE=false
 
 # Copy the runtime
-COPY --from=installBundle /opt/ibm/wlp /opt/ibm/wlp
+COPY --from=installBundle --chown=1001:0 /opt/ibm/wlp /opt/ibm/wlp
 
 COPY --chown=1001:0 server.xml /config/
 

--- a/ga/latest/full/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/full/Dockerfile.ubuntu.ibmjava8
@@ -14,8 +14,6 @@
 
 FROM websphere-liberty:kernel-java8-ibmjava
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubuntu.openjdk11
+++ b/ga/latest/full/Dockerfile.ubuntu.openjdk11
@@ -14,8 +14,6 @@
 
 FROM websphere-liberty:kernel-java11-openj9
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 

--- a/ga/latest/full/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/full/Dockerfile.ubuntu.openjdk17
@@ -14,8 +14,6 @@
 
 FROM websphere-liberty:kernel-java17-openj9
 
-USER root
-
 ARG VERBOSE=false
 ARG REPOSITORIES_PROPERTIES=""
 


### PR DESCRIPTION
To address the review comment: https://github.com/WASdev/ci.docker/pull/523#discussion_r1271084430

Remove `USER root` from the first-stage of UBI Dockerfiles for full image, since the operations don't need root user. Also use chown when copying files (not really necessary I think in this case, but for consistency)