### PR TITLE
Change /liberty symlink from /opt/ibm to /opt/ibm/wlp

### DIFF
--- a/ga/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -135,7 +135,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk11
@@ -135,7 +135,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk17
@@ -135,7 +135,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk8
@@ -135,7 +135,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \

--- a/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubuntu.ibmjava8
@@ -116,7 +116,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
@@ -111,7 +111,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
@@ -111,7 +111,7 @@ RUN mkdir /logs \
     && rm -rf /output \
     && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
     && ln -s /opt/ibm/wlp/usr/servers/defaultServer /config \
-    && ln -s /opt/ibm /liberty \
+    && ln -s /opt/ibm/wlp /liberty \
     && ln -s /opt/ibm/fixes /fixes \
     && ln -s /opt/ibm/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
     && mkdir -p /config/configDropins/defaults \


### PR DESCRIPTION
The `/liberty` symlink of WebSphere Liberty points to `/opt/ibm` while Open Liberty's symlink points to `/opt/ol/wlp`. This discrepancy defeats the purpose of having this common path/symlink. Change the WebSphere Liberty's symlink to `/opt/ibm/wlp`. To minimize potential disruption to users, introduce this change in a monthly release (as opposed to a quarterly release) of Liberty. 

PR for https://github.com/WASdev/ci.docker/issues/474