### PR TITLE
Switch Ubuntu images back to focal

### DIFF
--- a/ga/23.0.0.7/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/23.0.0.7/kernel/Dockerfile.ubuntu.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/ga/23.0.0.7/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/23.0.0.7/kernel/Dockerfile.ubuntu.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-focal
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-focal
 
 USER root
 


### PR DESCRIPTION
Semeru JRE images based on Ubuntu jammy (ibm-semeru-runtimes:open-11-jre-jammy) don't support ppc64le. So switch back to focal for now. 