### PR TITLE
Fix up permissions when a different user restores

### DIFF
--- a/ga/latest/kernel/helpers/build/checkpoint.sh
+++ b/ga/latest/kernel/helpers/build/checkpoint.sh
@@ -9,5 +9,13 @@ done
 echo "Performing checkpoint --at=$1"
 /opt/ibm/wlp/bin/server checkpoint defaultServer --at=$1
 
+# Find all directories in logs/ and output/ that the current user has read/write/execute permissions for
+# and give the same permissions to the group.
+find -L /logs /output -type d -readable -writable -executable -exec chmod g+rwx {} \;
+
+# Find all files in logs/ and output/ that the current user has read/write permissions for
+# and give the same permissions to the group.
+find -L /logs /output -type f -readable -writable -exec chmod g+rw {} \;
+
 rc=$?
 exit $rc


### PR DESCRIPTION
During checkpoint the current user creates
resources and directories for which the restore
user needs permission to read and write.

This change fixes up the permissions to allow
a different from the checkpoint user to restore
the process.