### PR TITLE
Update to UBI 9 (23.0.0.10+)

### DIFF
--- a/ga/23.0.0.10/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/23.0.0.10/kernel/Dockerfile.ubi.ibmjava8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmjava:8-ubi AS getRuntime
+FROM ibmjava:8-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install unzip wget openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM ibmjava:8-ubi
+FROM ibmjava:8-ubi9
 
 USER root
 

--- a/ga/23.0.0.10/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/23.0.0.10/kernel/Dockerfile.ubi.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9
 
 USER root
 

--- a/ga/23.0.0.10/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/23.0.0.10/kernel/Dockerfile.ubi.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/ga/23.0.0.10/kernel/Dockerfile.ubi.openjdk8
+++ b/ga/23.0.0.10/kernel/Dockerfile.ubi.openjdk8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubi.ibmjava8
+++ b/ga/latest/kernel/Dockerfile.ubi.ibmjava8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibmjava:8-ubi AS getRuntime
+FROM ibmjava:8-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install unzip wget openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM ibmjava:8-ubi
+FROM ibmjava:8-ubi9
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-11-jdk-ubi9
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-17-jdk-ubi9
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubi.openjdk8
+++ b/ga/latest/kernel/Dockerfile.ubi.openjdk8
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi AS getRuntime
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9 AS getRuntime
 
 USER root
 
@@ -38,7 +38,7 @@ RUN yum -y install shadow-utils unzip wget findutils openssl \
     && chmod -R g+rw /opt/ibm/wlp \
     && cp -a /opt/ibm/wlp/lafiles/. /licenses/
 
-FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi
+FROM icr.io/appcafe/ibm-semeru-runtimes:open-8-jdk-ubi9
 
 USER root
 


### PR DESCRIPTION
- Use Semeru images based on UBI 9 the base image for Liberty 23.0.0.10+
- Update the tag of IBM Java base image to use UBI 9. PR to create this new base image is here: https://github.ibm.com/was-docker/build-liberty-images-ubi/pull/301