### PR TITLE
Enable GitHub Actions workflow to automate new release updates

### DIFF
--- a/.github/workflows/update_files_for_release.yml
+++ b/.github/workflows/update_files_for_release.yml
@@ -1,0 +1,61 @@
+# This workflow is triggered by manual inputs.
+
+name: Update files for the new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      OLD_VERSION:
+        description: 'Enter old version'
+        # Show defaults as examples so user enters correct format.
+        default: '23.0.0.11'
+        required: true
+        type: string
+      NEW_VERSION:
+        description: 'Enter new version'
+        default: '23.0.0.12'
+        required: true
+        type: string
+      BUILD_LABEL:
+        description: 'Enter build label of release driver'
+        default: 'replace_with_gm_driver_label'
+        required: false
+        type: string
+
+jobs:
+  automate_release_updates:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Show useful information about the environment
+      run: echo "🔎 The name of the branch is ${{ github.ref }} and repository is ${{ github.repository }}."
+
+    - name: Check out repository code
+      uses: actions/checkout@v4
+      with:
+        ref: vNext
+        repository: wraschke/ci.docker
+
+    - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+
+    - name: Run update.sh script
+      run: bash ./update.sh ${{ inputs.OLD_VERSION }} ${{ inputs.NEW_VERSION }} ${{ inputs.BUILD_LABEL }}
+
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with: 
+        default_author: github_actions
+        author_name: GitHub Actions
+        message: "Updates for the release of ${{ inputs.NEW_VERSION }}"
+        add: '${{ github.workspace }}/ga/*'
+        new_branch: "${{ inputs.NEW_VERSION }}-release"
+        push: true
+        tag_push: '--force'
+
+    - name: Create Pull Request
+      run: |
+        gh pr create -B vNext -H "${{ inputs.NEW_VERSION }}-release" -r mbroz2 -r leochr --title "Updates for the release of ${{ inputs.NEW_VERSION }}" --body "Created by Github Actions"
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+echo "Hello from the update.sh script!"
+echo $(date)
+
+# Set variables to the positional parameters
+OLD_VERSION=$1
+NEW_VERSION=$2
+BUILD_LABEL=$3
+
+# See if NEW_VERSION and OLD_VERSION fit expected pattern.
+if [[ $OLD_VERSION =~ 2[3-9]\.0\.0\.[0-9]+ && $NEW_VERSION =~ 2[3-9]\.0\.0\.[0-9]+ ]];
+then
+   echo "$OLD_VERSION and $NEW_VERSION matches expected version format."
+else
+   echo "Either $OLD_VERSION or $NEW_VERSION does not fit expected version format."
+   exit 1;
+fi
+
+# Get last digit of old version
+OLD_SHORT_VERSION=${OLD_VERSION:7}
+
+echo "OLD_VERSION = $OLD_VERSION"
+echo "NEW_VERSION = $NEW_VERSION"
+echo "BUILD_LABEL = $BUILD_LABEL"
+echo "OLD_SHORT_VERSION = $OLD_SHORT_VERSION"
+
+echo "Copying latest files to $NEW_VERSION"
+cp -r ./ga/latest ./ga/$NEW_VERSION
+
+# Perform the substitutions in both latest and $NEW_VERSION directories.
+for file in $(find ./ga/latest ./ga/$NEW_VERSION -name Dockerfile.*); do
+   echo "Processing $file";
+
+   sed -i'.bak' -e "s/$OLD_VERSION/$NEW_VERSION/" $file;
+   sed -i'.bak' -e "s/ARG LIBERTY_BUILD_LABEL=.*/ARG LIBERTY_BUILD_LABEL=$BUILD_LABEL/g" $file;
+
+   # Do these substitutions only in $NEW_VERSION, not latest.
+   if [[ "$file" == "./ga/$NEW_VERSION/"* ]];
+   then
+      sed -i'.bak' -e "s/ARG PARENT_IMAGE=icr.io\/appcafe\/websphere-liberty:kernel/ARG PARENT_IMAGE=icr.io\/appcafe\/websphere-liberty:$NEW_VERSION-kernel/g" $file;
+      sed -i'.bak' -e "s/FROM websphere-liberty:kernel/FROM websphere-liberty:$NEW_VERSION-kernel/g" $file;
+   fi
+   
+   # Clean up temp files
+   rm $file.bak
+
+done
+
+cp ./ga/$OLD_VERSION/images.txt ./ga/$NEW_VERSION/images.txt;
+sed -i'.bak' -e "s/$OLD_VERSION/$NEW_VERSION/g" ./ga/$NEW_VERSION/images.txt;
+rm ./ga/$NEW_VERSION/images.txt.bak;
+
+if [[ $(( $OLD_SHORT_VERSION % 3 )) -eq 0 ]]
+  then
+      :
+  else
+      rm -rf ./ga/$OLD_VERSION
+  fi
+
+# Finally, comment out "ga/*/*/resources/*" in .gitignore so
+# newly created $NEW_VERSION/full/resources and $NEW_VERSION/kernel/resources 
+# directories can be committed and pushed.
+sed -i'.bak' -e "s/ga\/\*\/\*\/resources\/\*/#ga\/\*\/\*\/resources\/\*/g" .gitignore
+rm ./.gitignore.bak
+
+echo "Done performing file updates.";


### PR DESCRIPTION
This pull request's objective is [Fully automate the vNext updates in ci.docker repos for an upcoming release](https://github.ibm.com/was-docker/build-liberty-images-ubi/issues/292#).

Workflow run demonstrating objectives met: https://github.com/wraschke/ci.docker/actions/runs/6669536508/job/18127527479

Resulting pull request: https://github.com/wraschke/ci.docker/pull/20/files

Note that this is a run done only in my fork. Workflows can only run in the default branch of a repository, so these changes need to go into main. Obviously, I cannot test this workflow in the WASdev/ci.docker's until these changes are merged into main.

