### PR TITLE
Use `-XX:+IProfileDuringStartupPhase` in `populate_scc.sh` scripts

### DIFF
--- a/ga/24.0.0.1/kernel/helpers/build/populate_scc.sh
+++ b/ga/24.0.0.1/kernel/helpers/build/populate_scc.sh
@@ -42,7 +42,8 @@ fi
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+# Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/ga/latest/kernel/helpers/build/populate_scc.sh
+++ b/ga/latest/kernel/helpers/build/populate_scc.sh
@@ -42,7 +42,8 @@ fi
 # In order to reduce the chances of this happening we use the -XX:+OriginalJDK8HeapSizeCompatibilityMode
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode $SCC"
+# Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
+export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"


### PR DESCRIPTION
Add `-XX:+IProfileDuringStartupPhase` option to the populate scc script

When populating the SCC during the build of both the Liberty and app containers, the JVM can disable the IProfiler collection during JVM startup to enhance startup time, but this limits the amount of IProfiler information that can be stored into the SCC.

OpenJ9 can now support `-XX:+IProfileDuringStartupPhase` to enforce collecting IProfiler information during startup and better populate the SCC, which can be used in the `populate_scc.sh` script.

The option will be ignored if the used OpenJ9 build does not have the new option implemented.

Effect is larger amount of JIT Data in the SCC after a `populate_scc` run.
There’s no functional implications on Liberty, and performance effect is application dependent.

> In AcmeAir micro-services we see a jump in the amount of `JIT Data` stored in the SCC when using this option in the `populate_scc.sh` script, from 140KB to 524KB (and from 132KB to 388KB for the Liberty container layer). Performance effect shows around 1.5% better throughput with default setup, and no noticeable rampup change. I don’t have results on startup effect, but warm/production-runs won’t use the option.

Other than OpenJ9 testing, we have used the option in the `populate_scc.sh` script during the CI process of building the containers.


OpenJ9 PR: https://github.com/eclipse-openj9/openj9/pull/18381

Corresponding OpenLiberty PR: https://github.com/OpenLiberty/ci.docker/pull/482 
