### PR TITLE
New LIBERTY_SHA argument needs boilerplate text

### DIFF
--- a/create-new-release.sh
+++ b/create-new-release.sh
@@ -41,6 +41,8 @@ for file in $(find ./ga/latest ./ga/$NEW_VERSION -name Dockerfile.*); do
    then
       sed -i'.bak' -e "s/ARG PARENT_IMAGE=icr.io\/appcafe\/websphere-liberty:kernel/ARG PARENT_IMAGE=icr.io\/appcafe\/websphere-liberty:$NEW_VERSION-kernel/g" $file;
       sed -i'.bak' -e "s/FROM websphere-liberty:kernel/FROM websphere-liberty:$NEW_VERSION-kernel/g" $file;
+      
+      sed -i'.bak' -e "s/LIBERTY_SHA=.*/LIBERTY_SHA={replace_with_correct_sha}/" $file;
    fi
    
    # Clean up temp files


### PR DESCRIPTION
I tested the added `sed` command locally with expected results so I think that verification is enough.