### PR TITLE
Merge main into vNext

### DIFF
--- a/ga/24.0.0.10/kernel/helpers/runtime/docker-server.sh
+++ b/ga/24.0.0.10/kernel/helpers/runtime/docker-server.sh
@@ -61,7 +61,7 @@ function importKeyCert() {
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
   if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
-    mkdir /tmp/certs
+    mkdir -p /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
     csplit -s -z -f crt- "${TMP_CERT}" "${CRT_DELIMITER}" '{*}'

--- a/ga/24.0.0.6/kernel/helpers/runtime/docker-server.sh
+++ b/ga/24.0.0.6/kernel/helpers/runtime/docker-server.sh
@@ -61,7 +61,7 @@ function importKeyCert() {
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
   if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
-    mkdir /tmp/certs
+    mkdir -p /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
     csplit -s -z -f crt- "${TMP_CERT}" "${CRT_DELIMITER}" '{*}'

--- a/ga/24.0.0.9/kernel/helpers/runtime/docker-server.sh
+++ b/ga/24.0.0.9/kernel/helpers/runtime/docker-server.sh
@@ -61,7 +61,7 @@ function importKeyCert() {
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
   if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
-    mkdir /tmp/certs
+    mkdir -p /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
     csplit -s -z -f crt- "${TMP_CERT}" "${CRT_DELIMITER}" '{*}'

--- a/ga/latest/kernel/helpers/runtime/docker-server.sh
+++ b/ga/latest/kernel/helpers/runtime/docker-server.sh
@@ -61,7 +61,7 @@ function importKeyCert() {
   # Add kubernetes CA certificates to the truststore
   # CA bundles need to be split and added as individual certificates
   if [ "$SEC_IMPORT_K8S_CERTS" = "true" ] && [ -d "${KUBE_SA_FOLDER}" ]; then
-    mkdir /tmp/certs
+    mkdir -p /tmp/certs
     pushd /tmp/certs >&/dev/null
     cat ${KUBE_SA_FOLDER}/*.crt >${TMP_CERT}
     csplit -s -z -f crt- "${TMP_CERT}" "${CRT_DELIMITER}" '{*}'


### PR DESCRIPTION
Include the fix for https://github.com/WASdev/ci.docker/issues/645 into vNext

Note: This is to fix a critical issue encountered in EASeJ (Liberty SaaS) environment, hence making an exception to merge the fix after Liberty container images Dcut.