### PR TITLE
Update full Semeru 21 images to the correct base kernel image

### DIFF
--- a/ga/24.0.0.12/full/Dockerfile.ubi.openjdk21
+++ b/ga/24.0.0.12/full/Dockerfile.ubi.openjdk21
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:24.0.0.12-kernel-java21-openj9-ubi9-minimal
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:24.0.0.12-kernel-java21-openj9-ubi-minimal
 FROM $PARENT_IMAGE AS installBundle
 
 ARG VERBOSE=false
@@ -36,7 +36,7 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:24.0.0.12-kernel-java21-openj9-ubi9-minimal
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:24.0.0.12-kernel-java21-openj9-ubi-minimal
 FROM $PARENT_IMAGE
 ARG VERBOSE=false
 

--- a/ga/25.0.0.3/full/Dockerfile.ubi.openjdk21
+++ b/ga/25.0.0.3/full/Dockerfile.ubi.openjdk21
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:25.0.0.3-kernel-java21-openj9-ubi9-minimal
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:25.0.0.3-kernel-java21-openj9-ubi-minimal
 FROM $PARENT_IMAGE AS installBundle
 
 ARG VERBOSE=false
@@ -36,7 +36,7 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:25.0.0.3-kernel-java21-openj9-ubi9-minimal
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:25.0.0.3-kernel-java21-openj9-ubi-minimal
 FROM $PARENT_IMAGE
 ARG VERBOSE=false
 

--- a/ga/latest/full/Dockerfile.ubi.openjdk21
+++ b/ga/latest/full/Dockerfile.ubi.openjdk21
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java21-openj9-ubi9-minimal
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java21-openj9-ubi-minimal
 FROM $PARENT_IMAGE AS installBundle
 
 ARG VERBOSE=false
@@ -36,7 +36,7 @@ RUN set -eux; \
   rm -rf /output/workarea /output/logs; \
   find /opt/ibm/wlp ! -perm -g=rw -print0 | xargs -r -0 chmod g+rw;
 
-ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java21-openj9-ubi9-minimal
+ARG PARENT_IMAGE=icr.io/appcafe/websphere-liberty:kernel-java21-openj9-ubi-minimal
 FROM $PARENT_IMAGE
 ARG VERBOSE=false
 


### PR DESCRIPTION
Updating the full Liberty images with Semeru 21 images to use the correct base kernel image.

This issue doesn't affect the building of the Liberty image in the pipeline as the `PARENT_IMAGE` variable is set to the correct base image. But it can affect external users. So, update to use the proper base image. 

Open Liberty already use the right base images, so this change is not needed for it. 