### PR TITLE
Infinispan client update

### DIFF
--- a/ga/latest/kernel/helpers/build/infinispan-client-setup.sh
+++ b/ga/latest/kernel/helpers/build/infinispan-client-setup.sh
@@ -12,9 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-. /opt/ibm/helpers/build/internal/logger.sh
+#. /opt/ibm/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
+
+INFINISPAN_CLIENT_VERSION=${INFINISPAN_CLIENT_VERSION:-10.1.3.Final}
+USE_LATEST_COMPATIBLE=${USE_LATEST_COMPATIBLE:-false}
 
 pkgcmd=yum
 if ! command $pkgcmd
@@ -25,8 +28,12 @@ fi
 $pkgcmd update -y
 $pkgcmd install -y maven
 mkdir -p /opt/ibm/wlp/usr/shared/resources/infinispan
-echo '<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">  <modelVersion>4.0.0</modelVersion>   <groupId>io.openliberty</groupId>  <artifactId>openliberty-infinispan-client</artifactId>  <version>1.0</version>  <!-- https://mvnrepository.com/artifact/org.infinispan/infinispan-jcache-remote -->  <dependencies>    <dependency>      <groupId>org.infinispan</groupId>      <artifactId>infinispan-jcache-remote</artifactId>      <version>10.1.3.Final</version>    </dependency>  </dependencies></project>' > /opt/ibm/wlp/usr/shared/resources/infinispan/pom.xml
-mvn -f /opt/ibm/wlp/usr/shared/resources/infinispan/pom.xml versions:use-latest-releases -DallowMajorUpdates=false
+echo '<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">  <modelVersion>4.0.0</modelVersion>   <groupId>io.openliberty</groupId>  <artifactId>openliberty-infinispan-client</artifactId>  <version>1.0</version>  <!-- https://mvnrepository.com/artifact/org.infinispan/infinispan-jcache-remote -->  <dependencies>    <dependency>      <groupId>org.infinispan</groupId>      <artifactId>infinispan-jcache-remote</artifactId>      <version>'${INFINISPAN_CLIENT_VERSION}'</version>    </dependency>  </dependencies></project>' > /opt/ibm/wlp/usr/shared/resources/infinispan/pom.xml
+
+if [ "${USE_LATEST_COMPATIBLE}" = "true" ]; then
+  echo "[INFO] Finding latest compatible version..."
+  mvn -f /opt/ibm/wlp/usr/shared/resources/infinispan/pom.xml versions:use-latest-releases -DallowMajorUpdates=false
+fi
 mvn -f /opt/ibm/wlp/usr/shared/resources/infinispan/pom.xml dependency:copy-dependencies -DoutputDirectory=/opt/ibm/wlp/usr/shared/resources/infinispan
 # This fails with dependency errors using microdnf on ubi-minimal, but it is okay to let it fail
 yum remove -y maven || true
@@ -38,3 +45,7 @@ rm -rf ~/.m2
 chown -R 1001:0 /opt/ibm/wlp/usr/shared/resources/infinispan
 chmod -R g+rw /opt/ibm/wlp/usr/shared/resources/infinispan
 
+INSTALLED_VERSION=$(find /opt/ibm/wlp/usr/shared/resources/infinispan/ -name "*infinispan-commons*" -printf "%f\n" | sed 's/infinispan-commons-\(.*\).jar/\1/')
+if [ -n "$INSTALLED_VERSION" ]; then
+  echo "[INFO] Successfully installed Infinispan client version: ${INSTALLED_VERSION}"
+fi

--- a/ga/latest/kernel/helpers/build/infinispan-client-setup.sh
+++ b/ga/latest/kernel/helpers/build/infinispan-client-setup.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#. /opt/ibm/helpers/build/internal/logger.sh
+. /opt/ibm/helpers/build/internal/logger.sh
 
 set -Eeox pipefail
 


### PR DESCRIPTION
Fixes #673 

Previously hardcoded client version in pom.xml generation is replaced with configurable version at build time or via env in Dockerfile.

Adds support for the following environment variables and build args:
- INFINISPAN_CLIENT_VERSION: Set the base version of the client
- USE_LATEST_COMPATIBLE: If true, script uses latest compatible version using `versions:use-latest-releases`

