### PR TITLE
Remove deprecation message

### DIFF
--- a/ga/25.0.0.11/kernel/helpers/build/internal/logger.sh
+++ b/ga/25.0.0.11/kernel/helpers/build/internal/logger.sh
@@ -27,10 +27,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based WebSphere Liberty container image in Docker Hub ('ibmcom/websphere-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM ibmcom/websphere-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/websphere-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/wl-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/ga/25.0.0.3/kernel/helpers/build/internal/logger.sh
+++ b/ga/25.0.0.3/kernel/helpers/build/internal/logger.sh
@@ -27,10 +27,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based WebSphere Liberty container image in Docker Hub ('ibmcom/websphere-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM ibmcom/websphere-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/websphere-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/wl-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/ga/25.0.0.6/kernel/helpers/build/internal/logger.sh
+++ b/ga/25.0.0.6/kernel/helpers/build/internal/logger.sh
@@ -27,10 +27,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based WebSphere Liberty container image in Docker Hub ('ibmcom/websphere-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM ibmcom/websphere-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/websphere-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/wl-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/ga/25.0.0.9/kernel/helpers/build/internal/logger.sh
+++ b/ga/25.0.0.9/kernel/helpers/build/internal/logger.sh
@@ -27,10 +27,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based WebSphere Liberty container image in Docker Hub ('ibmcom/websphere-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM ibmcom/websphere-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/websphere-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/wl-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main

--- a/ga/latest/kernel/helpers/build/internal/logger.sh
+++ b/ga/latest/kernel/helpers/build/internal/logger.sh
@@ -27,10 +27,4 @@ function showLogs() {
     exec 1>&3 3>&- 2>&4 4>&-
 }
 
-function logDeprecationNotice() {
-    echo "Deprecation notice: IBM expects the last version of the UBI-based WebSphere Liberty container image in Docker Hub ('ibmcom/websphere-liberty') to be 25.0.0.3. To continue to receive updates and security fixes after 25.0.0.3, you must switch to using the images from the IBM Container Registry (ICR). To switch, simply update 'FROM ibmcom/websphere-liberty' in your Dockerfiles to 'FROM icr.io/appcafe/websphere-liberty'. The same image tags from Docker Hub are also available in ICR. Ubuntu-based Liberty container images will continue to be available from Docker Hub. For more information, see https://ibm.biz/wl-ubi-containers-dh-deprecation"
-}
-
-logDeprecationNotice
-
 main


### PR DESCRIPTION
Now that we've stopped pushing UBI images to Docker Hub, we can remove the deprecation message. Users still pulling images from Docker Hub would still see that message (from the old images that they pull). 