### PR TITLE
Update the base Semeru image for Ubuntu

### DIFF
--- a/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2023.
+# (C) Copyright IBM Corporation 2023, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/26.0.0.1/kernel/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2023.
+# (C) Copyright IBM Corporation 2023, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-11-jre-jammy
+FROM ibm-semeru-runtimes:open-11-jre-noble
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk11
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2023.
+# (C) Copyright IBM Corporation 2023, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ibm-semeru-runtimes:open-17-jre-jammy
+FROM ibm-semeru-runtimes:open-17-jre-noble
 
 USER root
 

--- a/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
+++ b/ga/latest/kernel/Dockerfile.ubuntu.openjdk17
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2023.
+# (C) Copyright IBM Corporation 2023, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update base Semeru image for Ubuntu to use noble instead of jammy to resolve security vulnerabilities. This change will be effective in Liberty 26.0.0.1 container images and onwards. 