### PR TITLE
Create the LTPA keys password by default on 26.0.0.5+

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": "fbf6a96d49214c0abc6a3bc5da6e48cd|REPLACE|PWD_TRUST|SECRET|keyStore|secret|rootpwd|dbpassword"
   },
-  "generated_at": "2026-05-05T16:57:06Z",
+  "generated_at": "2026-05-15T15:51:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -813,10 +813,18 @@
     ],
     "ga/26.0.0.5/kernel/helpers/runtime/docker-server.sh": [
       {
+        "hashed_secret": "196ce2adfe494f21d7fe2adcd3bcf4ff4e267b92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad321232b1e4e90a29208e1f70d06aad788caa16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 147,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1001,10 +1009,18 @@
     ],
     "ga/latest/kernel/helpers/runtime/docker-server.sh": [
       {
+        "hashed_secret": "196ce2adfe494f21d7fe2adcd3bcf4ff4e267b92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ad321232b1e4e90a29208e1f70d06aad788caa16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 147,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ This section describes the optional build variables that can be enabled via the 
   *  XML Snippet Location:  [keystore.xml](ga/latest/kernel/helpers/build/configuration_snippets/keystore.xml).
 * `VERBOSE`
   *  Description: When set to `true` it outputs the commands and results to stdout from `configure.sh`. Otherwise, default setting is `false` and `configure.sh` is silenced.
+* `GENERATE_LTPA_KEYS_PASSWORD` (26.0.0.5+)
+  * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
+  * Default: `"true"`.
+  * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.
 
 
 ### Deprecated Build Variables
@@ -117,13 +121,6 @@ The following container image build variables are now **deprecated** and will be
 
 Single Sign-On can be optionally configured by adding Liberty server variables in an xml file, by passing environment variables (less secure),
 or by passing Liberty server variables in through the Liberty operator. See [SECURITY.md](SECURITY.md).
-
-The following runtime environment variables control security-related behavior:
-
-* `GENERATE_LTPA_KEYS_PASSWORD` (environment variable, 26.0.0.5+)
-  * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
-  * Default: `"true"`.
-  * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.
 
 ## OpenJ9 Shared Class Cache (SCC)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ The following container image build variables are now **deprecated** and will be
 Single Sign-On can be optionally configured by adding Liberty server variables in an xml file, by passing environment variables (less secure),
 or by passing Liberty server variables in through the Liberty operator. See [SECURITY.md](SECURITY.md).
 
+The following runtime environment variables control security-related behavior:
+
+* `GENERATE_LTPA_KEYS_PASSWORD` (environment variable, 26.0.0.5+)
+  * Description: Automatically generates a secure random password for LTPA keys and exports it as the `ltpa_keys_password` environment variable. This prevents the LTPA service from failing with error `CWWKS4118E` when no LTPA keys password is configured.
+  * Default: `"true"`.
+  * Note: If `ltpa_keys_password` is already set, automatic generation is skipped. Set to `"false"` to disable.
+
 ## OpenJ9 Shared Class Cache (SCC)
 
 OpenJ9's SCC allows the VM to store Java classes in an optimized form that can be loaded very quickly, JIT compiled code, and profiling data. Deploying an SCC file together with your application can significantly improve start-up time. The SCC can also be shared by multiple VMs, thereby reducing total memory consumption.

--- a/ga/26.0.0.5/kernel/helpers/runtime/docker-server.sh
+++ b/ga/26.0.0.5/kernel/helpers/runtime/docker-server.sh
@@ -114,6 +114,12 @@ keystorePathOverride="$SNIPPETS_TARGET_OVERRIDES/keystore.xml"
 
 importKeyCert
 
+
+if [ "${GENERATE_LTPA_KEYS_PASSWORD:-true}" = "true" ] && [ -z "$ltpa_keys_password" ]; then
+  export ltpa_keys_password=$(openssl rand -base64 32 2>/dev/null)
+  echo "Generated ltpa_keys_password for LTPA configuration"
+fi
+
 # Infinispan Session Caching
 if [[ -n "$INFINISPAN_SERVICE_NAME" ]]; then
  echo "INFINISPAN_SERVICE_NAME(original): ${INFINISPAN_SERVICE_NAME}"

--- a/ga/latest/kernel/helpers/runtime/docker-server.sh
+++ b/ga/latest/kernel/helpers/runtime/docker-server.sh
@@ -114,6 +114,12 @@ keystorePathOverride="$SNIPPETS_TARGET_OVERRIDES/keystore.xml"
 
 importKeyCert
 
+
+if [ "${GENERATE_LTPA_KEYS_PASSWORD:-true}" = "true" ] && [ -z "$ltpa_keys_password" ]; then
+  export ltpa_keys_password=$(openssl rand -base64 32 2>/dev/null)
+  echo "Generated ltpa_keys_password for LTPA configuration"
+fi
+
 # Infinispan Session Caching
 if [[ -n "$INFINISPAN_SERVICE_NAME" ]]; then
  echo "INFINISPAN_SERVICE_NAME(original): ${INFINISPAN_SERVICE_NAME}"


### PR DESCRIPTION
- Creates a random LTPA keys password `ltpa_keys_password` (environment variable) by default unless `GENERATE_LTPA_KEYS_PASSWORD` is set to `false` or the variable is already set. 

For https://github.com/OpenLiberty/ci.docker/issues/718