### PR TITLE
Disable GCContainerHeuristics option in scc helper script for all ga + latest

### DIFF
--- a/ga/25.0.0.12/kernel/helpers/build/populate_scc.sh
+++ b/ga/25.0.0.12/kernel/helpers/build/populate_scc.sh
@@ -45,7 +45,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/ga/26.0.0.3/kernel/helpers/build/populate_scc.sh
+++ b/ga/26.0.0.3/kernel/helpers/build/populate_scc.sh
@@ -45,7 +45,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/ga/26.0.0.6/kernel/helpers/build/populate_scc.sh
+++ b/ga/26.0.0.6/kernel/helpers/build/populate_scc.sh
@@ -45,7 +45,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/ga/26.0.0.8/kernel/helpers/build/populate_scc.sh
+++ b/ga/26.0.0.8/kernel/helpers/build/populate_scc.sh
@@ -45,7 +45,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"

--- a/ga/latest/kernel/helpers/build/populate_scc.sh
+++ b/ga/latest/kernel/helpers/build/populate_scc.sh
@@ -45,7 +45,12 @@ fi
 # option to revert to the old criteria, which results in AOT code that is more compatible, on average, with typical heap sizes/positions.
 # The option has no effect on later JDKs.
 # Using -XX:+IProfileDuringStartupPhase to enforce IProfiler collection during the startup phase to better populate the SCC.
-export OPENJ9_JAVA_OPTIONS="-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
+# Disable GCContainerHeuristics for ibmjava JVMs as workaround for ibmjava 8.0.8.70 build failures
+GC_OPT=""
+if [ -d "/opt/ibm/java" ]; then
+  GC_OPT="-XX:-GCContainerHeuristics "
+fi
+export OPENJ9_JAVA_OPTIONS="${GC_OPT}-XX:+OriginalJDK8HeapSizeCompatibilityMode -XX:+IProfileDuringStartupPhase $SCC"
 export IBM_JAVA_OPTIONS="$OPENJ9_JAVA_OPTIONS"
 CREATE_LAYER="$OPENJ9_JAVA_OPTIONS,createLayer,groupAccess"
 DESTROY_LAYER="$OPENJ9_JAVA_OPTIONS,destroy"


### PR DESCRIPTION
Addresses: https://github.com/ibmruntimes/ci.docker/issues/178 ,  https://github.com/WASdev/ci.docker/issues/778 

Disable the `GCContainerHeuristics` option in `populate_scc.sh` for all releases for OpenLiberty images as they are causing build/rebuild failures on all ibmjava8 based images for ibmjava 8.0.8.70.

PR for Open Liberty: https://github.com/OpenLiberty/ci.docker/pull/741
